### PR TITLE
Add files via upload

### DIFF
--- a/Operating System 12587603 - 1Mb PCM - 2004 model year_unlocked.xdf
+++ b/Operating System 12587603 - 1Mb PCM - 2004 model year_unlocked.xdf
@@ -1,0 +1,14890 @@
+<!-- Written 07/09/2021 07:51:33 -->
+<XDFFORMAT version="1.60">
+  <XDFHEADER>
+    <flags>0x1</flags>
+    <fileversion>2019-01</fileversion>
+    <deftitle>OS12587603 - 2004 1Mb PCM</deftitle>
+    <description>Parameters for Operating System (OS) 12587603.&#013;&#010;This OS was used in 2004 GM vehicles, including Flex Fuel vehicles.&#013;&#010;The PCM is a 1 Mb, with Blue and Green 80 pin connectors.</description>
+    <author>Credited to LRT</author>
+    <BASEOFFSET offset="0" subtract="0" />
+    <DEFAULTS datasizeinbits="16" sigdigits="2" outputtype="1" signed="0" lsbfirst="0" float="0" />
+    <REGION type="0xFFFFFFFF" startaddress="0x0" size="0xFFFFF" regionflags="0x0" name="Binary File" desc="This region describes the bin file edited by this XDF" />
+    <CATEGORY index="0x0" name="VATS" />
+    <CATEGORY index="0x1" name="Airflow" />
+    <CATEGORY index="0x2" name="Crank / Start" />
+    <CATEGORY index="0x3" name="DFCO" />
+    <CATEGORY index="0x4" name="Open Loop / PE" />
+    <CATEGORY index="0x5" name="Fuel Injectors" />
+    <CATEGORY index="0x6" name="Oxygen Sensors" />
+    <CATEGORY index="0x7" name="Abuse Management" />
+    <CATEGORY index="0x8" name="Rev Limiter" />
+    <CATEGORY index="0x9" name="Idle" />
+    <CATEGORY index="0xA" name="Spark" />
+    <CATEGORY index="0xB" name="Knock" />
+    <CATEGORY index="0xC" name="Torque Limiting" />
+    <CATEGORY index="0xD" name="Transmission" />
+    <CATEGORY index="0xE" name="Fuel Tank / EVAP" />
+    <CATEGORY index="0xF" name="Fans / AC" />
+    <CATEGORY index="0x10" name="System" />
+    <CATEGORY index="0x11" name="Tach" />
+    <CATEGORY index="0x12" name="Speedometer" />
+    <CATEGORY index="0x13" name="Diagnostics" />
+    <CATEGORY index="0x14" name="DTC" />
+    <CATEGORY index="0x15" name="Flex Fuel" />
+    <CATEGORY index="0x16" name="Operating System" />
+    <CATEGORY index="0x17" name="Fuel System" />
+  </XDFHEADER>
+  <XDFTABLE uniqueid="0x75FA" flags="0x0">
+    <title>F0507 Convert Primary Sender to Volume</title>
+    <description>The PCM uses this table to convert the signal from the primary fuel tank level sender to actual liters for the PCM&apos;s internal calculations.&#013;&#010;&#013;&#010;Note: This table is setup for 2003 PCM. &#013;&#010;(For other year models, invert table)</description>
+    <CATEGORYMEM index="0" category="24" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gallons</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>65</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <indexcount>81</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="20.00" />
+      <LABEL index="1" value="22.00" />
+      <LABEL index="2" value="24.00" />
+      <LABEL index="3" value="26.00" />
+      <LABEL index="4" value="28.00" />
+      <LABEL index="5" value="30.00" />
+      <LABEL index="6" value="32.00" />
+      <LABEL index="7" value="34.00" />
+      <LABEL index="8" value="36.00" />
+      <LABEL index="9" value="38.00" />
+      <LABEL index="10" value="40.00" />
+      <LABEL index="11" value="42.00" />
+      <LABEL index="12" value="44.00" />
+      <LABEL index="13" value="46.00" />
+      <LABEL index="14" value="48.00" />
+      <LABEL index="15" value="50.00" />
+      <LABEL index="16" value="52.00" />
+      <LABEL index="17" value="54.00" />
+      <LABEL index="18" value="56.00" />
+      <LABEL index="19" value="58.00" />
+      <LABEL index="20" value="60.00" />
+      <LABEL index="21" value="62.00" />
+      <LABEL index="22" value="64.00" />
+      <LABEL index="23" value="66.00" />
+      <LABEL index="24" value="68.00" />
+      <LABEL index="25" value="70.00" />
+      <LABEL index="26" value="72.00" />
+      <LABEL index="27" value="74.00" />
+      <LABEL index="28" value="76.00" />
+      <LABEL index="29" value="78.00" />
+      <LABEL index="30" value="80.00" />
+      <LABEL index="31" value="82.00" />
+      <LABEL index="32" value="84.00" />
+      <LABEL index="33" value="86.00" />
+      <LABEL index="34" value="88.00" />
+      <LABEL index="35" value="90.00" />
+      <LABEL index="36" value="92.00" />
+      <LABEL index="37" value="94.00" />
+      <LABEL index="38" value="96.00" />
+      <LABEL index="39" value="98.00" />
+      <LABEL index="40" value="100.00" />
+      <LABEL index="41" value="102.00" />
+      <LABEL index="42" value="104.00" />
+      <LABEL index="43" value="106.00" />
+      <LABEL index="44" value="108.00" />
+      <LABEL index="45" value="110.00" />
+      <LABEL index="46" value="112.00" />
+      <LABEL index="47" value="114.00" />
+      <LABEL index="48" value="116.00" />
+      <LABEL index="49" value="118.00" />
+      <LABEL index="50" value="120.00" />
+      <LABEL index="51" value="122.00" />
+      <LABEL index="52" value="124.00" />
+      <LABEL index="53" value="126.00" />
+      <LABEL index="54" value="128.00" />
+      <LABEL index="55" value="130.00" />
+      <LABEL index="56" value="132.00" />
+      <LABEL index="57" value="134.00" />
+      <LABEL index="58" value="136.00" />
+      <LABEL index="59" value="138.00" />
+      <LABEL index="60" value="140.00" />
+      <LABEL index="61" value="142.00" />
+      <LABEL index="62" value="144.00" />
+      <LABEL index="63" value="146.00" />
+      <LABEL index="64" value="148.00" />
+      <LABEL index="65" value="150.00" />
+      <LABEL index="66" value="152.00" />
+      <LABEL index="67" value="154.00" />
+      <LABEL index="68" value="156.00" />
+      <LABEL index="69" value="158.00" />
+      <LABEL index="70" value="160.00" />
+      <LABEL index="71" value="162.00" />
+      <LABEL index="72" value="164.00" />
+      <LABEL index="73" value="166.00" />
+      <LABEL index="74" value="168.00" />
+      <LABEL index="75" value="170.00" />
+      <LABEL index="76" value="172.00" />
+      <LABEL index="77" value="174.00" />
+      <LABEL index="78" value="176.00" />
+      <LABEL index="79" value="178.00" />
+      <LABEL index="80" value="180.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x1E20C" mmedelementsizebits="16" mmedrowcount="81" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>255.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.004128">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7DD" flags="0x0">
+    <title>F0508 Convert Primary Sender to Volume for Gauge</title>
+    <description>The PCM uses this table to convert the signal from the primary fuel tank level sender to actual liters for controlling the fuel gauge needle.&#013;&#010;&#013;&#010;Note: This table is setup for 2003 PCM. &#013;&#010;(For other year models, invert table)</description>
+    <CATEGORYMEM index="0" category="24" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gallons</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>65</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <indexcount>129</indexcount>
+      <datatype>0</datatype>
+      <unittype>26</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="2.00" />
+      <LABEL index="2" value="4.00" />
+      <LABEL index="3" value="6.00" />
+      <LABEL index="4" value="8.00" />
+      <LABEL index="5" value="10.00" />
+      <LABEL index="6" value="12.00" />
+      <LABEL index="7" value="14.00" />
+      <LABEL index="8" value="16.00" />
+      <LABEL index="9" value="18.00" />
+      <LABEL index="10" value="20.00" />
+      <LABEL index="11" value="22.00" />
+      <LABEL index="12" value="24.00" />
+      <LABEL index="13" value="26.00" />
+      <LABEL index="14" value="28.00" />
+      <LABEL index="15" value="30.00" />
+      <LABEL index="16" value="32.00" />
+      <LABEL index="17" value="34.00" />
+      <LABEL index="18" value="36.00" />
+      <LABEL index="19" value="38.00" />
+      <LABEL index="20" value="40.00" />
+      <LABEL index="21" value="42.00" />
+      <LABEL index="22" value="44.00" />
+      <LABEL index="23" value="46.00" />
+      <LABEL index="24" value="48.00" />
+      <LABEL index="25" value="50.00" />
+      <LABEL index="26" value="52.00" />
+      <LABEL index="27" value="54.00" />
+      <LABEL index="28" value="56.00" />
+      <LABEL index="29" value="58.00" />
+      <LABEL index="30" value="60.00" />
+      <LABEL index="31" value="62.00" />
+      <LABEL index="32" value="64.00" />
+      <LABEL index="33" value="66.00" />
+      <LABEL index="34" value="68.00" />
+      <LABEL index="35" value="70.00" />
+      <LABEL index="36" value="72.00" />
+      <LABEL index="37" value="74.00" />
+      <LABEL index="38" value="76.00" />
+      <LABEL index="39" value="78.00" />
+      <LABEL index="40" value="80.00" />
+      <LABEL index="41" value="82.00" />
+      <LABEL index="42" value="84.00" />
+      <LABEL index="43" value="86.00" />
+      <LABEL index="44" value="88.00" />
+      <LABEL index="45" value="90.00" />
+      <LABEL index="46" value="92.00" />
+      <LABEL index="47" value="94.00" />
+      <LABEL index="48" value="96.00" />
+      <LABEL index="49" value="98.00" />
+      <LABEL index="50" value="100.00" />
+      <LABEL index="51" value="102.00" />
+      <LABEL index="52" value="104.00" />
+      <LABEL index="53" value="106.00" />
+      <LABEL index="54" value="108.00" />
+      <LABEL index="55" value="110.00" />
+      <LABEL index="56" value="112.00" />
+      <LABEL index="57" value="114.00" />
+      <LABEL index="58" value="116.00" />
+      <LABEL index="59" value="118.00" />
+      <LABEL index="60" value="120.00" />
+      <LABEL index="61" value="122.00" />
+      <LABEL index="62" value="124.00" />
+      <LABEL index="63" value="126.00" />
+      <LABEL index="64" value="128.00" />
+      <LABEL index="65" value="130.00" />
+      <LABEL index="66" value="132.00" />
+      <LABEL index="67" value="134.00" />
+      <LABEL index="68" value="136.00" />
+      <LABEL index="69" value="138.00" />
+      <LABEL index="70" value="140.00" />
+      <LABEL index="71" value="142.00" />
+      <LABEL index="72" value="144.00" />
+      <LABEL index="73" value="146.00" />
+      <LABEL index="74" value="148.00" />
+      <LABEL index="75" value="150.00" />
+      <LABEL index="76" value="152.00" />
+      <LABEL index="77" value="154.00" />
+      <LABEL index="78" value="156.00" />
+      <LABEL index="79" value="158.00" />
+      <LABEL index="80" value="160.00" />
+      <LABEL index="81" value="162.00" />
+      <LABEL index="82" value="164.00" />
+      <LABEL index="83" value="166.00" />
+      <LABEL index="84" value="168.00" />
+      <LABEL index="85" value="170.00" />
+      <LABEL index="86" value="172.00" />
+      <LABEL index="87" value="174.00" />
+      <LABEL index="88" value="176.00" />
+      <LABEL index="89" value="178.00" />
+      <LABEL index="90" value="180.00" />
+      <LABEL index="91" value="182.00" />
+      <LABEL index="92" value="184.00" />
+      <LABEL index="93" value="186.00" />
+      <LABEL index="94" value="188.00" />
+      <LABEL index="95" value="190.00" />
+      <LABEL index="96" value="192.00" />
+      <LABEL index="97" value="194.00" />
+      <LABEL index="98" value="196.00" />
+      <LABEL index="99" value="198.00" />
+      <LABEL index="100" value="200.00" />
+      <LABEL index="101" value="202.00" />
+      <LABEL index="102" value="204.00" />
+      <LABEL index="103" value="206.00" />
+      <LABEL index="104" value="208.00" />
+      <LABEL index="105" value="210.00" />
+      <LABEL index="106" value="212.00" />
+      <LABEL index="107" value="214.00" />
+      <LABEL index="108" value="216.00" />
+      <LABEL index="109" value="218.00" />
+      <LABEL index="110" value="220.00" />
+      <LABEL index="111" value="222.00" />
+      <LABEL index="112" value="224.00" />
+      <LABEL index="113" value="226.00" />
+      <LABEL index="114" value="228.00" />
+      <LABEL index="115" value="230.00" />
+      <LABEL index="116" value="232.00" />
+      <LABEL index="117" value="234.00" />
+      <LABEL index="118" value="236.00" />
+      <LABEL index="119" value="238.00" />
+      <LABEL index="120" value="240.00" />
+      <LABEL index="121" value="242.00" />
+      <LABEL index="122" value="244.00" />
+      <LABEL index="123" value="246.00" />
+      <LABEL index="124" value="248.00" />
+      <LABEL index="125" value="250.00" />
+      <LABEL index="126" value="252.00" />
+      <LABEL index="127" value="254.00" />
+      <LABEL index="128" value="256.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x1E410" mmedelementsizebits="16" mmedrowcount="129" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>255.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.004128">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x4B1D" flags="0x8">
+    <title>F0502 - Fuel Tank Size</title>
+    <description>Maximum capacity of the fuel tank.&#013;&#010;</description>
+    <EMBEDDEDDATA mmedaddress="0x1E1D0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Gallons</units>
+    <rangehigh>200.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0042373">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xC4" flags="0x8">
+    <title>F0503 - Fuel Tank Size for Guage</title>
+    <description>Maximum capacity of the fuel tank, used for controlling the fuel gauge needle.&#013;&#010;</description>
+    <EMBEDDEDDATA mmedaddress="0x1E1D4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Gallons</units>
+    <rangehigh>200.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.004181">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3D86" flags="0x8">
+    <title>F0504 - Primary Fuel Tank Size</title>
+    <description>Maximum capacity of the primary fuel tank if the system uses a primary and secondary tank.&#013;&#010;</description>
+    <EMBEDDEDDATA mmedaddress="0x1E1DC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Gallons</units>
+    <rangehigh>200.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0042373">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x75BC" flags="0x8">
+    <title>F0505 - Primary Fuel Tank Size for Guage</title>
+    <description>Maximum capacity of the primary fuel tank, used for controlling the fuel gauge needle.&#013;&#010;</description>
+    <EMBEDDEDDATA mmedaddress="0x1E1DE" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Gallons</units>
+    <rangehigh>200.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.004181">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x322B" flags="0x30">
+    <title>Calibration Segment Information</title>
+    <description>*** These parameters are displayed for information purposes only - NEVER change ***&#013;&#010;&#013;&#010;Oper System = the main Operating System (OS) programmed in the calibration.&#013;&#010;&#013;&#010;This is displayed solely to ensure that the correct XDF file is used to edit the BIN file.</description>
+    <CATEGORYMEM index="0" category="17" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Calibration #</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Segment</units>
+      <indexcount>8</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Oper System" />
+      <LABEL index="1" value="Engine Cal" />
+      <LABEL index="2" value="Engine Dia" />
+      <LABEL index="3" value="Trans Cal" />
+      <LABEL index="4" value="Trans Dia" />
+      <LABEL index="5" value="Fuel System" />
+      <LABEL index="6" value="System" />
+      <LABEL index="7" value="Speedometer" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedrowcount="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>0.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="1" equation="X">
+        <VAR id="X" type="address" address="0x504" sizeinbits="32" />
+      </MATH>
+      <MATH row="2" col="1" equation="X">
+        <VAR id="X" type="address" address="0x8004" sizeinbits="32" />
+      </MATH>
+      <MATH row="3" col="1" equation="X">
+        <VAR id="X" type="address" address="0x162D4" sizeinbits="32" />
+      </MATH>
+      <MATH row="4" col="1" equation="X">
+        <VAR id="X" type="address" address="0x19604" sizeinbits="32" />
+      </MATH>
+      <MATH row="5" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1D8B4" sizeinbits="32" />
+      </MATH>
+      <MATH row="6" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1E1B4" sizeinbits="32" />
+      </MATH>
+      <MATH row="7" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1F6C4" sizeinbits="32" />
+      </MATH>
+      <MATH row="8" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1FEB4" sizeinbits="32" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x63A0" flags="0x30">
+    <title>Checksum Information</title>
+    <description>*** These parameters are displayed for information purposes only - NEVER change ***&#013;&#010;&#013;&#010;These parameters are displayed solely as a confirmation that all Checksums are being updated (as necessary) - each time the BIN file is changed, and then resaved.</description>
+    <CATEGORYMEM index="0" category="17" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Checksum</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Segment</units>
+      <indexcount>8</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Oper System" />
+      <LABEL index="1" value="Engine Cal" />
+      <LABEL index="2" value="Engine Dia" />
+      <LABEL index="3" value="Trans Cal" />
+      <LABEL index="4" value="Trans Dia" />
+      <LABEL index="5" value="Fuel System" />
+      <LABEL index="6" value="System" />
+      <LABEL index="7" value="Speedometer" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedrowcount="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>0.000000</max>
+      <outputtype>3</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="1" equation="X">
+        <VAR id="X" type="address" address="0x500" sizeinbits="16" />
+      </MATH>
+      <MATH row="2" col="1" equation="X">
+        <VAR id="X" type="address" address="0x8000" sizeinbits="16" />
+      </MATH>
+      <MATH row="3" col="1" equation="X">
+        <VAR id="X" type="address" address="0x162D0" sizeinbits="16" />
+      </MATH>
+      <MATH row="4" col="1" equation="X">
+        <VAR id="X" type="address" address="0x19600" sizeinbits="16" />
+      </MATH>
+      <MATH row="5" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1D8B0" sizeinbits="16" />
+      </MATH>
+      <MATH row="6" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1E1B0" sizeinbits="16" />
+      </MATH>
+      <MATH row="7" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1F6C0" sizeinbits="16" />
+      </MATH>
+      <MATH row="8" col="1" equation="X">
+        <VAR id="X" type="address" address="0x1FEB0" sizeinbits="16" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4EF0" flags="0x30">
+    <title>VIN</title>
+    <description>This MAY be the Vehicle Indentification Number (VIN) programmed in the calibration.&#013;&#010;&#013;&#010;*** Do NOT make changes to this parameter, UNLESS the originally dsiplayed values were in proper VIN format (i.e. make certain this is indeed a VIN stored in the PCM) ***</description>
+    <CATEGORYMEM index="0" category="17" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <indexcount>17</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>2</datatype>
+      <unittype>2</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1" />
+      <LABEL index="1" value="2" />
+      <LABEL index="2" value="3" />
+      <LABEL index="3" value="4" />
+      <LABEL index="4" value="5" />
+      <LABEL index="5" value="6" />
+      <LABEL index="6" value="7" />
+      <LABEL index="7" value="8" />
+      <LABEL index="8" value="9" />
+      <LABEL index="9" value="10" />
+      <LABEL index="10" value="11" />
+      <LABEL index="11" value="12" />
+      <LABEL index="12" value="13" />
+      <LABEL index="13" value="14" />
+      <LABEL index="14" value="15" />
+      <LABEL index="15" value="16" />
+      <LABEL index="16" value="17" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>VIN</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>2</datatype>
+      <unittype>2</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="VIN" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x4021" mmedelementsizebits="8" mmedrowcount="1" mmedcolcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>48.000000</min>
+      <max>90.000000</max>
+      <outputtype>4</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH col="1" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH col="2" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="1" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="2" equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x94F" flags="0x30">
+    <title>VIN - possible alternate location</title>
+    <description>This MAY be the Vehicle Indentification Number (VIN) programmed in the calibration.&#013;&#010;&#013;&#010;*** Do NOT make changes to this parameter, UNLESS the originally dsiplayed values were in proper VIN format (i.e. make certain this is indeed a VIN stored in the PCM) ***</description>
+    <CATEGORYMEM index="0" category="17" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <indexcount>17</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>2</datatype>
+      <unittype>2</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1" />
+      <LABEL index="1" value="2" />
+      <LABEL index="2" value="3" />
+      <LABEL index="3" value="4" />
+      <LABEL index="4" value="5" />
+      <LABEL index="5" value="6" />
+      <LABEL index="6" value="7" />
+      <LABEL index="7" value="8" />
+      <LABEL index="8" value="9" />
+      <LABEL index="9" value="10" />
+      <LABEL index="10" value="11" />
+      <LABEL index="11" value="12" />
+      <LABEL index="12" value="13" />
+      <LABEL index="13" value="14" />
+      <LABEL index="14" value="15" />
+      <LABEL index="15" value="16" />
+      <LABEL index="16" value="17" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>VIN</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>2</datatype>
+      <unittype>2</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="VIN" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x6021" mmedelementsizebits="8" mmedrowcount="1" mmedcolcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>48.000000</min>
+      <max>90.000000</max>
+      <outputtype>4</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH col="1" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH col="2" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="1" equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="2" equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x122A" flags="0xC">
+    <title>Engine Type</title>
+    <description>Displays the Engine Type programmed in the calibration.&#013;&#010;&#013;&#010;*** This parameter should NOT be changed ***&#013;&#010;&#013;&#010;0=5.3L&#013;&#010;1=5.7L&#013;&#010;2=4.8L&#013;&#010;3=6.0L&#013;&#010;4=4.3L&#013;&#010;5=5.0L&#013;&#010;6=8.1L&#013;&#010;7=5.7L HO</description>
+    <CATEGORYMEM index="0" category="17" />
+    <EMBEDDEDDATA mmedaddress="0x8108" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <outputtype>2</outputtype>
+    <decimalpl>1</decimalpl>
+    <rangehigh>7.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1357" flags="0xC">
+    <title>Number of Cylinders</title>
+    <description>The number of Engine Cylinders in the calibration.&#013;&#010;&#013;&#010;*** This parameter should NOT be changed ***</description>
+    <CATEGORYMEM index="0" category="17" />
+    <EMBEDDEDDATA mmedaddress="0x8109" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Cylinders</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>8.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1F4B" flags="0xC">
+    <title>Transmission Type</title>
+    <description>Displays the Transmission Type programmed in the calibration.&#013;&#010;&#013;&#010;*** This parameter should NOT be changed ***&#013;&#010;&#013;&#010;0 = 4L60E&#013;&#010;1 = 4L80E&#013;&#010;2 = Manual&#013;&#010;3 = Non-Electronic Automatic&#013;&#010;4 = Allison</description>
+    <CATEGORYMEM index="0" category="17" />
+    <EMBEDDEDDATA mmedaddress="0x1961E" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <outputtype>2</outputtype>
+    <decimalpl>1</decimalpl>
+    <rangehigh>4.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x342A" flags="0xC">
+    <title>Transmission Range Switch / Gear Indicator Type</title>
+    <description>Elects if a Transmission Range Switch / Gear Indicator Type (if any) is used by the vehicle.&#013;&#010;&#013;&#010;0 = None (no transmission mounted Range Switch - like a Camaro)&#013;&#010;1 = PRNDL Range Switch (transmission mounted Range Switch - like Corvettes and most Trucks)&#013;&#010;2 = P/N only Switch (like Trucks with the Allison Transmission)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <EMBEDDEDDATA mmedaddress="0x1F77A" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <outputtype>2</outputtype>
+    <decimalpl>1</decimalpl>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x51CB" flags="0x30">
+    <title>B0101 - Main VE Table (Grams*Kelivin/kPa)</title>
+    <description>This is the main Volumetric Efficiency (VE) table.  The cell units are in Grams*Kelvin/kPa.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = MAP&#013;&#010;&#013;&#010;The values in this table represent the efficiency of the engine&apos;s ability to fill the cylinders with air.  It is used to predict the volume of air entering each cylinder under varying conditions.&#013;&#010;&#013;&#010;The air mass per cylinder can be determined from the VE table using the following formula:&#013;&#010;&#013;&#010;g/cyl = VE*MAP/Charge Temperature&#013;&#010;&#013;&#010;Where:&#013;&#010;VE is in g*K/kPa,&#013;&#010;MAP is in kPa,&#013;&#010;Charge Temperature is in degrees Kelvin.</description>
+    <CATEGORYMEM index="0" category="2" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>20</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1200" />
+      <LABEL index="3" value="1600" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2400" />
+      <LABEL index="6" value="2800" />
+      <LABEL index="7" value="3200" />
+      <LABEL index="8" value="3600" />
+      <LABEL index="9" value="4000" />
+      <LABEL index="10" value="4400" />
+      <LABEL index="11" value="4800" />
+      <LABEL index="12" value="5200" />
+      <LABEL index="13" value="5600" />
+      <LABEL index="14" value="6000" />
+      <LABEL index="15" value="6400" />
+      <LABEL index="16" value="6800" />
+      <LABEL index="17" value="7200" />
+      <LABEL index="18" value="7600" />
+      <LABEL index="19" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MAP (kPA)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="15" />
+      <LABEL index="1" value="20" />
+      <LABEL index="2" value="25" />
+      <LABEL index="3" value="30" />
+      <LABEL index="4" value="35" />
+      <LABEL index="5" value="40" />
+      <LABEL index="6" value="45" />
+      <LABEL index="7" value="50" />
+      <LABEL index="8" value="55" />
+      <LABEL index="9" value="60" />
+      <LABEL index="10" value="65" />
+      <LABEL index="11" value="70" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="80" />
+      <LABEL index="14" value="85" />
+      <LABEL index="15" value="90" />
+      <LABEL index="16" value="95" />
+      <LABEL index="17" value="100" />
+      <LABEL index="18" value="105" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x8442" mmedelementsizebits="16" mmedrowcount="19" mmedcolcount="20" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Grams*Kelvin/kPa</units>
+      <decimalpl>4</decimalpl>
+      <min>0.000000</min>
+      <max>10.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0001953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1513" flags="0x30">
+    <title>B0102 - VE While Cranking (Grams*Kelvin/kPa)</title>
+    <description>Volumetric Efficiency (VE) table used while the engine is Cranking.  The cell units are in Grams*Kelvin/kPa.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = MAP</description>
+    <CATEGORYMEM index="0" category="2" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>33</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="40" />
+      <LABEL index="2" value="80" />
+      <LABEL index="3" value="120" />
+      <LABEL index="4" value="160" />
+      <LABEL index="5" value="200" />
+      <LABEL index="6" value="240" />
+      <LABEL index="7" value="280" />
+      <LABEL index="8" value="320" />
+      <LABEL index="9" value="360" />
+      <LABEL index="10" value="400" />
+      <LABEL index="11" value="440" />
+      <LABEL index="12" value="480" />
+      <LABEL index="13" value="520" />
+      <LABEL index="14" value="560" />
+      <LABEL index="15" value="600" />
+      <LABEL index="16" value="640" />
+      <LABEL index="17" value="680" />
+      <LABEL index="18" value="720" />
+      <LABEL index="19" value="760" />
+      <LABEL index="20" value="800" />
+      <LABEL index="21" value="840" />
+      <LABEL index="22" value="880" />
+      <LABEL index="23" value="920" />
+      <LABEL index="24" value="960" />
+      <LABEL index="25" value="1000" />
+      <LABEL index="26" value="1040" />
+      <LABEL index="27" value="1080" />
+      <LABEL index="28" value="1120" />
+      <LABEL index="29" value="1160" />
+      <LABEL index="30" value="1200" />
+      <LABEL index="31" value="1240" />
+      <LABEL index="32" value="1280" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>kPA</units>
+      <indexcount>9</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="20" />
+      <LABEL index="1" value="30" />
+      <LABEL index="2" value="40" />
+      <LABEL index="3" value="50" />
+      <LABEL index="4" value="60" />
+      <LABEL index="5" value="70" />
+      <LABEL index="6" value="80" />
+      <LABEL index="7" value="90" />
+      <LABEL index="8" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x81F0" mmedelementsizebits="16" mmedrowcount="9" mmedcolcount="33" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Grams*Kelvin/kPa</units>
+      <decimalpl>4</decimalpl>
+      <min>0.000000</min>
+      <max>10.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0001953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x43AB" flags="0xC">
+    <title>B0104 - Cylinder Volume</title>
+    <description>The volume in Cubic Centimeters (CC) of each Engine Cylinder.</description>
+    <CATEGORYMEM index="0" category="2" />
+    <EMBEDDEDDATA mmedaddress="0x875C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>CC</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>1600.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0305175">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x5FB2" flags="0xC">
+    <title>B0105 - Wide Open Throttle (WOT)</title>
+    <description>Minimum Throttle Position (% TPS) that the PCM still considers the TPS to be at WOT.</description>
+    <CATEGORYMEM index="0" category="2" />
+    <EMBEDDEDDATA mmedaddress="0x88D0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x73A" flags="0xC">
+    <title>B0107 - Max Speed for Idle Mode</title>
+    <description>If Vehicle Speed (MPH) is above this value, and Throttle Position (%) is above Max Throttle for Idle Mode (B0108), then airflow will be calculated as Non-Idle.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0x88D2" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x44BE" flags="0xC">
+    <title>B0108 - Max Throttle for Idle Mode</title>
+    <description>If the Throttle Position (%) is above this, and Vehicle Speed (MPH) is above Max Speed for Idle Mode (B0107), then airflow will be calculated as Non-Idle.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0x88D4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xBCD" flags="0xC">
+    <title>B0120 - RPM Threshold for Airflow Calculation</title>
+    <description>If Engine Speed (RPM) is less than this value, then the PCM uses a dynamically calculated airflow value to determine grams of air per cylinder.  While the airflow is in a Steady State, a correction factor is updated based on the airflow difference between the MAF Sensed Airflow and the MAP Calculated Airflow (Speed Density Airflow).&#013;&#010;&#013;&#010;During rapid changes in airflow, the correction factor is applied to the airflow calculations to compensate.&#013;&#010;&#013;&#010;If Engine Speed (RPM) is above this value, then the PCM will use the MAF Sensor exclusively (if not disabled by DTCs) to calculate grams of air per cylinder.  No updates are made to the airflow correction factor.</description>
+    <CATEGORYMEM index="0" category="2" />
+    <EMBEDDEDDATA mmedaddress="0x8760" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12800.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2AED" flags="0xC">
+    <title>B0203 - AIR Pump Coolant Temp Disable</title>
+    <description>Engine Coolant Temperature (ECT) must be above this value to allow the AIR Pump to operate.</description>
+    <CATEGORYMEM index="0" category="17" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x892A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x273D" flags="0xC">
+    <title>B0401 - BTM Enable RPM</title>
+    <description>The Engine RPM must be this much above Idle RPM, before Brake Torque Management (BTM) can become active.&#013;&#010;&#013;&#010;Brake Torque Management (BTM) is used to reduce Engine Power by cutting cylinders and reducing the pedal opening on ETC vehicles when your foot is held on the Brake in Gear, and the Accelerator is pressed (i.e doing a &quot;Burn Out&quot;).&#013;&#010;&#013;&#010;Disable BTM:&#013;&#010;Set the Enable RPM (B0401) to high value (i.e. 8000 RPM)&#013;&#010;Set the Disable RPM (B0402) to high value (i.e. 7900 RPM)</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x8AF4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12700.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x5C9F" flags="0xC">
+    <title>B0402 - BTM Disable RPM</title>
+    <description>Once Brake Torque Management (BTM) is active, the Engine RPM must fall back down to this many RPMs above Idle RPM, before BTM will be disabled.&#013;&#010;Brake Torque Management (BTM) is used to reduce Engine Power by cutting cylinders and reducing the pedal opening on ETC vehicles when your foot is held on the Brake in Gear, and the Accelerator is pressed (i.e doing a &quot;Burn Out&quot;).&#013;&#010;&#013;&#010;Disable BTM:&#013;&#010;Set the Enable RPM (B0401) to high value (i.e. 8000 RPM)&#013;&#010;Set the Disable RPM (B0402) to high value (i.e. 7900 RPM)</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x8AF2" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12700.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6534" flags="0xC">
+    <title>B0501 - EVAP Purge Canister Min Temp</title>
+    <description>Engine Coolant Temperature (ECT) must be above this value to allow the Purge Canister (EVAP) to operate.</description>
+    <CATEGORYMEM index="0" category="15" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x8EBC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFFLAG uniqueid="0x5D81">
+    <title>B0701 - Catalytic Converter Protection Enable</title>
+    <description>Unchecked = Catalytic Converter Protection is Disabled&#013;&#010;&#013;&#010;Checked = Catalytic Converter Protection is Enabled</description>
+    <CATEGORYMEM index="0" category="17" />
+    <EMBEDDEDDATA mmedaddress="0x8E70" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x6828" flags="0xC">
+    <title>B1201 - Abuse Management Upper RPM Threshold (in Gear)</title>
+    <description>If the Transmission is in Gear, and the Engine RPM is greater than this value, then Abuse Mode will be Enabled.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x9426" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.1953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x67BD" flags="0xC">
+    <title>B1202 - Abuse Management Lower RPM Threshold (in Gear)</title>
+    <description>If Abuse Management is active and the Transmission is in Gear, then Engine RPM must fall below this value to disable Abuse Management once active.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x9428" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.1953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x38EA" flags="0xC">
+    <title>B1203 - Abuse Management Upper RPM Threshold (in P/N)</title>
+    <description>If the Transmission is in Park or Neutral, and the Engine RPM is greater than this value, then Abuse Mode will be Enabled.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x942A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.1953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4142" flags="0xC">
+    <title>B1204 - Abuse Management Lower RPM Threshold (in P/N)</title>
+    <description>If Abuse Management is active and the Transmission is in Park or Neutral, then Engine RPM must fall below this value to disable Abuse Management once active.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x942C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.1953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2508" flags="0xC">
+    <title>B1205 - Abuse Management Upper TPS Threshold (%)</title>
+    <description>If the Throttle is above this value (% TPS), but the RPM is below Abuse Management Upper RPM Threshold (in Gear) (B1201), then Abuse Mode is Enabled.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x942E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.01953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7351" flags="0xC">
+    <title>B1206 - Abuse Management Lower TPS Threshold (%)</title>
+    <description>If Abuse Management is active, then the Throttle must fall below this value (% TPS) to disable Abuse Management.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x9430" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.01953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x26F2" flags="0xC">
+    <title>B1207 - Abuse Management Vehicle Speed Threshold (MPH)</title>
+    <description>If the Vehicle Speed (MPH) is above this value, then Abuse Management is disabled.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x9432" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0078125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2E96" flags="0xC">
+    <title>B1208 - Abuse Management Commanded Fuel (EQ Ratio)</title>
+    <description>If Abuse Management is active, then this will be the Commanded Fuel (EQ Ratio).</description>
+    <CATEGORYMEM index="0" category="8" />
+    <EMBEDDEDDATA mmedaddress="0x9434" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>EQ Ratio</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>63.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.000976562">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x1114" flags="0x30">
+    <title>B1209 - Abuse Management TIme</title>
+    <description>If Abuse Management is active and the conditions to disable it are met, then they must be met for this long (seonds) before Abuse Management will be disabled.</description>
+    <CATEGORYMEM index="0" category="8" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x9438" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.00625">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFFLAG uniqueid="0x7B16">
+    <title>B1301 - EGR System Enable</title>
+    <description>Unchecked = EGR System is Disabled&#013;&#010;&#013;&#010;Checked = EGR System is Enabled</description>
+    <CATEGORYMEM index="0" category="17" />
+    <EMBEDDEDDATA mmedaddress="0x9458" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFFLAG uniqueid="0x1688">
+    <title>B1402 - Type of Knock Sensors</title>
+    <description>Unchecked = Resonant (LS1 type)&#013;&#010;&#013;&#010;Checked = Flat Response (LS2 and LS3 type)</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedaddress="0x810C" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x7C3D" flags="0xC">
+    <title>B1901 - Maximum Allowed Engine Torque</title>
+    <description>Maximum Allowed Engine Torque (Ft-lbs), used by the Traction Control System (TCS).</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x9AE4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ft-lbs</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>639.000000</rangehigh>
+    <rangelow>-639.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x6E30" flags="0x30">
+    <title>B1902 - Torque Loss from Spark Retard (%)</title>
+    <description>Amount of Torque Lost (%) from the Traction Control System (TCS) Spark Retard.  This table tells the PCM how much torque is lost (%) for a given amount of Spark Retard.&#013;&#010;&#013;&#010;Column headings = Fuel Ethanol Percentage (%)&#013;&#010;Row headings = Spark Retard (degrees)</description>
+    <CATEGORYMEM index="0" category="13" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Percent</units>
+      <indexcount>5</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0%" />
+      <LABEL index="1" value="10%" />
+      <LABEL index="2" value="20%" />
+      <LABEL index="3" value="50%" />
+      <LABEL index="4" value="80%" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>18</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Deg.  0" />
+      <LABEL index="1" value="3" />
+      <LABEL index="2" value="6" />
+      <LABEL index="3" value="9" />
+      <LABEL index="4" value="12" />
+      <LABEL index="5" value="15" />
+      <LABEL index="6" value="18" />
+      <LABEL index="7" value="21" />
+      <LABEL index="8" value="24" />
+      <LABEL index="9" value="27" />
+      <LABEL index="10" value="30" />
+      <LABEL index="11" value="33" />
+      <LABEL index="12" value="36" />
+      <LABEL index="13" value="39" />
+      <LABEL index="14" value="42" />
+      <LABEL index="15" value="45" />
+      <LABEL index="16" value="48" />
+      <LABEL index="17" value="51" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xA206" mmedelementsizebits="16" mmedrowcount="18" mmedcolcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.01953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFFLAG uniqueid="0x2C12">
+    <title>B3101 - Flex Fuel Option</title>
+    <description>Unchecked = Flex Fuel System is Disabled&#013;&#010;&#013;&#010;Checked = Flex Fuel System is Enabled&#013;&#010;&#013;&#010;*** an Ethanol (Flex Fuel) Sensor must be installed in the Fuel Line ***</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0xB7AC" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x7B38" flags="0xC">
+    <title>B3103 - Ethanol Default Percentage (%)</title>
+    <description>If the Ethanol Sensor is deemed to be faulty by the PCM, this value (%) is the Ethanol Default Percentage that will be assumed.</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0xB7B4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% Ethanol</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1B98" flags="0xC">
+    <title>B3104 - Ethanol Sensor Maximum Frequency (Hz)</title>
+    <description>If the Ethanol Sensor is reading above this value (Hz), then the PCM will default to the Ethanol Default Percentage (B3103).</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0x169EC" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Hz</units>
+    <decimalpl>0</decimalpl>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x429D" flags="0xC">
+    <title>B3105 - Ethanol Sensor Minimum Frequency (Hz)</title>
+    <description>If the Ethanol Sensor is reading below this value (Hz), then the PCM will default to the Ethanol Default Percentage (B3103).</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0x169ED" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Hz</units>
+    <decimalpl>0</decimalpl>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6D17" flags="0xC">
+    <title>Ethanol Sensor 0% Frequency (Hz)</title>
+    <description>The Ethanol Sensor output value (Hz) that equates to an Ethanol content of 0% in the fuel being used.</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0xB7B6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Hz</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>155.000000</rangehigh>
+    <rangelow>40.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.4882813">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1C57" flags="0xC">
+    <title>Ethanol Sensor Composition Slope (Factor)</title>
+    <description>Ethanol Sensor Composition Slope (Factor).</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0xB7B8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Factor</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0004882813">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x502" flags="0xC">
+    <title>Ethanol Composition Change - Update (%)</title>
+    <description>The minimum change (%) of the Ethanol content in the fuel being used, to update (change) related Ethanol (Flex Fuel) calculations.</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0xB7AE" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% change</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x41F2" flags="0xC">
+    <title>Ethanol Composition Change - Delay (Gallons)</title>
+    <description>The minimum volume of fuel flow (U.S. Gallons) required to initiate Ethanol (Flex Fuel) calculations.</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0xB7B0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Gallons</units>
+    <decimalpl>4</decimalpl>
+    <rangehigh>0.860000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.000013208">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7859" flags="0xC">
+    <title>Ethanol Composition Change - Transition (Gallons)</title>
+    <description>The minimum volume of fuel flow (U.S. Gallons) required to update Ethanol (Flex Fuel) calculations.</description>
+    <CATEGORYMEM index="0" category="22" />
+    <EMBEDDEDDATA mmedaddress="0xB7B2" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Gallons</units>
+    <decimalpl>4</decimalpl>
+    <rangehigh>0.860000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.000013208">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0xD06" flags="0x30">
+    <title>Cranking Ethanol Blend Factor</title>
+    <description>Cranking EQ Ratio Blend Factor - based on % Ethanol content in the fuel being used.</description>
+    <CATEGORYMEM index="0" category="22" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Factor</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Ethanol</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="10" />
+      <LABEL index="2" value="20" />
+      <LABEL index="3" value="30" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="60" />
+      <LABEL index="7" value="70" />
+      <LABEL index="8" value="80" />
+      <LABEL index="9" value="90" />
+      <LABEL index="10" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xD664" mmedelementsizebits="16" mmedrowcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0002441406">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x778F" flags="0x30">
+    <title>Cranking Ethanol Gain Factor</title>
+    <description>Cranking Fuel Multiplier - based on Engine Coolant Temperature (ECT) and % Ethanol content in the fuel being used.&#013;&#010;&#013;&#010;Column headings = Fuel Ethanol Percentage (%)&#013;&#010;Row headings = ECT (F)</description>
+    <CATEGORYMEM index="0" category="22" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Ethanol</units>
+      <indexcount>5</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0%" />
+      <LABEL index="1" value="10%" />
+      <LABEL index="2" value="20%" />
+      <LABEL index="3" value="50%" />
+      <LABEL index="4" value="80%" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F  -40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xB948" mmedelementsizebits="16" mmedrowcount="19" mmedcolcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>4.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0002441406">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6526" flags="0x30">
+    <title>Cranking Ethanol ECT Factor</title>
+    <description>Cranking Ethanol Fcator - based on Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;Column headings = Factor&#013;&#010;Row headings = ECT (F)</description>
+    <CATEGORYMEM index="0" category="22" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Factor</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Factor" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F  -40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0xD67A" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>4.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0004882813">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6DD2" flags="0x30">
+    <title>B3201 - Initial Fuel Prime</title>
+    <description>When the ignition key is first turned to the ON position the PCM will deliver a Prime Pulse of Fuel.  This table defines the amount of Fuel (Grams) to be injected.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xB826" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>15.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6119" flags="0x30">
+    <title>B3202 - Initial Fuel Prime Delay</title>
+    <description>Before the Initial Fuel Prime (B3201) pulse is delivered, the PCM will delay the Prime Pulse for this long (seconds) after key ON.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40.00" />
+      <LABEL index="1" value="-18.00" />
+      <LABEL index="2" value="3.00" />
+      <LABEL index="3" value="25.00" />
+      <LABEL index="4" value="46.00" />
+      <LABEL index="5" value="68.00" />
+      <LABEL index="6" value="90.00" />
+      <LABEL index="7" value="111.00" />
+      <LABEL index="8" value="133.00" />
+      <LABEL index="9" value="154.00" />
+      <LABEL index="10" value="176.00" />
+      <LABEL index="11" value="198.00" />
+      <LABEL index="12" value="219.00" />
+      <LABEL index="13" value="241.00" />
+      <LABEL index="14" value="262.00" />
+      <LABEL index="15" value="284.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xB7CC" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x21FF" flags="0x30">
+    <title>B3204 - Non Sequential First Fuel Pulse</title>
+    <description>Before the PCM switches to Sequential Injection Mode (after starting) this is the Mass (grams) of Fuel that will be injected.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xB846" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>15.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x38B5" flags="0x30">
+    <title>B3205 - Non Sequential First Fuel Pulse Delay</title>
+    <description>This many Crankshaft Reference Pulses must occur before the PCM will deliver the Non Sequential First Fuel Pulse (B3204).&#013;&#010;&#013;&#010;There are 24 Reference Pulses per Crankshaft Revolution.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Pulses</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xB886" mmedelementsizebits="8" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x746D" flags="0x30">
+    <title>B3206 - Non Sequential Second Fuel Pulse</title>
+    <description>Following the PCM delivering the Non Sequential First Fuel Pulse (B3204) after starting, this is the subsequent Mass (grams) of Fuel that will then be injected.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xB866" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>15.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x27BC" flags="0x30">
+    <title>B3207 - Non Sequential Second Fuel Pulse Delay</title>
+    <description>This many Crankshaft Reference Pulses must occur before the PCM will deliver the Non Sequential Second Fuel Pulse (B3206).&#013;&#010;&#013;&#010;There are 24 Reference Pulses per Crankshaft Revolution.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Pulses</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xB896" mmedelementsizebits="8" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2B0C" flags="0x30">
+    <title>B3303 - Fuel Cut-off Limiters in Gear (RPM)</title>
+    <description>This table configures the Fuel Cut-off Rev Limiter - when the transmission is in Gear.&#013;&#010;&#013;&#010;*** This is the main Rev Limiter ***&#013;&#010;&#013;&#010;Cut-off = when RPM reaches this value, Fuel will be cut&#013;&#010;&#013;&#010;Enable = after the Fuel has been cut, the RPM must fall to this value to re-enable Fuel</description>
+    <CATEGORYMEM index="0" category="9" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Cut-off" />
+      <LABEL index="1" value="Enable" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>10</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1st" />
+      <LABEL index="1" value="2nd" />
+      <LABEL index="2" value="3rd" />
+      <LABEL index="3" value="4th" />
+      <LABEL index="4" value="5th" />
+      <LABEL index="5" value="6th" />
+      <LABEL index="6" value="7th" />
+      <LABEL index="7" value="8th" />
+      <LABEL index="8" value="P/N" />
+      <LABEL index="9" value="Reverse" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xBAE8" mmedelementsizebits="16" mmedrowcount="10" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x22EA" flags="0x30">
+    <title>B3305 - Cold Engine Protection Timer</title>
+    <description>The PCM reads the Engine Coolant Temperature (ECT) at Startup, then based on that temperature, this table determines how long the Cold Engine RPM Limiters will be used.</description>
+    <CATEGORYMEM index="0" category="9" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xBB14" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x32C0" flags="0x30">
+    <title>B3306 - Cold Engine RPM Limiter</title>
+    <description>If the PCM has determined the engine is in a cold condition, based on Engine Coolant Temperature (ECT) at startup, this is the RPM Limiter Table that will be used.&#013;&#010;&#013;&#010;*** This is the main Rev Limiter when the engine is COLD ***&#013;&#010;&#013;&#010;Cut-off = when RPM reaches this value, Fuel will be cut&#013;&#010;&#013;&#010;Enable = after the Fuel has been cut, the RPM must fall to this value to re-enable Fuel</description>
+    <CATEGORYMEM index="0" category="9" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Cut-off" />
+      <LABEL index="1" value="Enable" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F -40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xBBFC" mmedelementsizebits="16" mmedrowcount="16" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0xDDC" flags="0xC">
+    <title>B3307 - DFCO Re-Enable Timer</title>
+    <description>If DFCO has been disabled, it cannot be re-enabled for this long (seconds) even if conditions to do so are met.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBB40" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2F14" flags="0xC">
+    <title>B3308 - DFCO Enable Temperature (Manual Trans)</title>
+    <description>Engine Coolant Temperature (ECT) must be above this to allow DFCO to occur - with a Manual transmission.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xBB42" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2FD8" flags="0xC">
+    <title>B3309 - DFCO Enable RPM (Manual Trans)</title>
+    <description>RPM must be above this value to allow DFCO to occur - with a Manual transmission.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBB44" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x412D" flags="0xC">
+    <title>B3310 - DFCO Enable MAP (Manual Trans)</title>
+    <description>Manifold Absolute Pressure (MAP) must be below this value to allow DFCO to occur - with a Manual transmission.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBB46" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MAP (kPa)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4E87" flags="0xC">
+    <title>B3311 - DFCO Enable TPS (Manual Trans)</title>
+    <description>Throttle Position (% TPS) must be below this value to allow DFCO to occur - with a Manual transmission.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBB48" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7529" flags="0xC">
+    <title>B3312 - DFCO Enable Speed (Manual Trans)</title>
+    <description>Vehicle Speed (MPH) must be above this value to allow DFCO to occur - with a Manual transmission.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBB4A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2DC" flags="0xC">
+    <title>B3313 - DFCO Enable Temperature</title>
+    <description>Engine Coolant Temperature (ECT) must be above this value to enable DFCO.&#013;&#010;&#013;&#010;When all of the DFCO enablers are met, hitting any DFCO activate level will turn on DFCO.  After DFCO has been enabled hitting any DFCO disabler, or hitting every DFCO deactivate, will turn off DFCO.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xBB4C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0xD9D" flags="0x30">
+    <title>B3314 - DFCO Vehicle Speed Enable</title>
+    <description>Vehicle Speed (MPH) must be above this value to enable DFCO.&#013;&#010;&#013;&#010;When all of the DFCO enablers are met, hitting any DFCO activate level will turn on DFCO. After DFCO has been enabled hitting any DFCO disabler, or hitting every DFCO deactivate, will turn off DFCO.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>BARO (kPa)</units>
+      <indexcount>5</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="65" />
+      <LABEL index="1" value="75" />
+      <LABEL index="2" value="85" />
+      <LABEL index="3" value="95" />
+      <LABEL index="4" value="105" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xBB56" mmedelementsizebits="16" mmedrowcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/128">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3F2D" flags="0x30">
+    <title>B3316 - DFCO Throttle Enable</title>
+    <description>Throttle Position (% TPS) must be below this value to enable DFCO.&#013;&#010;&#013;&#010;When all of the DFCO enablers are met, hitting any DFCO activate level will turn on DFCO. After DFCO has been enabled hitting any DFCO disabler, or hitting every DFCO deactivate, will turn off DFCO.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xBBA0" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3F66" flags="0x30">
+    <title>B3318 - DFCO RPM</title>
+    <description>The Engine RPM must be above the ENABLE value to activate DFCO.&#013;&#010;&#013;&#010;If DFCO is active, and Engine RPM falls below the DISABLE value, then DFCO will be deactivated.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Enable" />
+      <LABEL index="1" value="Disable" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>10</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1st" />
+      <LABEL index="1" value="2nd" />
+      <LABEL index="2" value="3rd" />
+      <LABEL index="3" value="4th" />
+      <LABEL index="4" value="5th" />
+      <LABEL index="5" value="6th" />
+      <LABEL index="6" value="7th" />
+      <LABEL index="7" value="8th" />
+      <LABEL index="8" value="P/N" />
+      <LABEL index="9" value="Reverse" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xBB60" mmedelementsizebits="16" mmedrowcount="10" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1B35" flags="0x30">
+    <title>B3320 - DFCO MAP</title>
+    <description>Manifold Absolute Pressure (MAP) must be below the ENABLE value to activate DFCO.&#013;&#010;&#013;&#010;If DFCO is active, and MAP value goes above the DISABLE value, then DFCO will be deactivated.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>kPa</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Enable" />
+      <LABEL index="1" value="Disable" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Baro (kPa)</units>
+      <indexcount>5</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="60" />
+      <LABEL index="1" value="70" />
+      <LABEL index="2" value="80" />
+      <LABEL index="3" value="90" />
+      <LABEL index="4" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xBB8C" mmedelementsizebits="16" mmedrowcount="5" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>105.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0xB8E" flags="0xC">
+    <title>B3322 - Fuel Cut-Off in P/N - VSS DTC</title>
+    <description>Cut Fuel if Engine Speed (RPM) goes above this value when transmission is in Park or Neutral, and a VSS DTC is present.</description>
+    <CATEGORYMEM index="0" category="9" />
+    <EMBEDDEDDATA mmedaddress="0xBAE4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1B8E" flags="0xC">
+    <title>B3323 - Fuel Re-Enable in P/N - VSS DTC</title>
+    <description>Re-enable Fuel if Engine Speed (RPM) falls below this value, when transmission is in Park or Neutral, and a VSS DTC is present.</description>
+    <CATEGORYMEM index="0" category="9" />
+    <EMBEDDEDDATA mmedaddress="0xBAE6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6FB3" flags="0xC">
+    <title>B3330 - Fuel Cut-Off in P/N</title>
+    <description>Cut Fuel if Engine Speed (RPM) goes above this value when transmission is in Park or Neutral.</description>
+    <CATEGORYMEM index="0" category="9" />
+    <EMBEDDEDDATA mmedaddress="0xBAE0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6752" flags="0xC">
+    <title>B3331 - Fuel Re-Enable in P/N</title>
+    <description>Re-enable Fuel if Engine Speed (RPM) falls below this value, when transmission is in Park or Neutral.</description>
+    <CATEGORYMEM index="0" category="9" />
+    <EMBEDDEDDATA mmedaddress="0xBAE2" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x106C" flags="0x30">
+    <title>B3334 - DFCO Spark Ramping In Rate</title>
+    <description>The is the Rate which the Spark Timing is Reduced to the value in DFCO Spark Timing (B3336), once DFCO becomes active.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Factor</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xBAB2" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x272A" flags="0x30">
+    <title>B3335 - DFCO Spark Ramping Out Rate</title>
+    <description>The is the Rate which the Spark Timing is Increased back to the normal running spark, once DFCO is Disabled.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>%TPS</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.30" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.80" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.30" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.80" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.30" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.80" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.30" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.80" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xBA66" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>10.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x64B9" flags="0x30">
+    <title>B3336 - DFCO Spark Timing (Degrees)</title>
+    <description>When DFCO is active the Timing will be Reduced to this amount until the fuel is cut.&#013;&#010;&#013;&#010;Also see:&#013;&#010;DFCO Spark Ramping In Rate (B3334)&#013;&#010;DFCO Spark Ramping Out Rate (B3335)</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xBA88" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>-40.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x64C9" flags="0xC">
+    <title>B3337 - DFCO Spark Transition Delay</title>
+    <description>This is the number of Crank Reference Pulses the PCM must wait before transitioning from table DFCO Spark Timing (B3336) to DFCO Spark Timing, High TPS (B5937) or DFCO Spark Timing, Low TPS (B5939).</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBA10" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ref pulses</units>
+    <outputtype>2</outputtype>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x136D" flags="0x30">
+    <title>B3601 - Ratio of Air to Fuel for Stoichiometry</title>
+    <description>The Air Fuel Ratio (AFR) considered to be Stoichiometric.  This value is used by the PCM to determine the AFR of an EQ Ratio of 1.0.&#013;&#010;&#013;&#010;AFR values for EQ Ratios are calculated by dividing this AFR  Stoichiometric value, by the specified EQ Ratio.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>AFR (Stoich)</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Ethanol</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xC7D4" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>8.000000</min>
+      <max>20.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="4096/X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x147C" flags="0x30">
+    <title>B3603 - Commanded Fuel When in Engine Protection Mode (EQ Ratio)</title>
+    <description>When the PCM is in Engine Protection Mode, this is the Commanded Fuel (EQ Ratio).  Engine Protection Fuelling Mode is enabled once the engine gets too hot.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Ratio of Air to Fuel for Stoichiometry (B3601)</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xC820" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x759" flags="0x30">
+    <title>B3604 - Commanded Fuel When Cranking (EQ Ratio)</title>
+    <description>When the engine is Cranking, this is the Commanded Fuel (EQ Ratio).  Based on Engine Coolant Temperature ECT) at startup and the number of times the 24x sensor indicates 90&#176; of Engine Rotation.&#013;&#010;&#013;&#010;Column headings = ECT (F)&#013;&#010;Row headings = 24x Counts&#013;&#010;&#013;&#010;Also see:&#013;&#010;Ratio of Air to Fuel for Stoichiometry (B3601)</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-02" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Pulses</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="01" />
+      <LABEL index="2" value="02" />
+      <LABEL index="3" value="03" />
+      <LABEL index="4" value="04" />
+      <LABEL index="5" value="05" />
+      <LABEL index="6" value="06" />
+      <LABEL index="7" value="07" />
+      <LABEL index="8" value="08" />
+      <LABEL index="9" value="09" />
+      <LABEL index="10" value="10" />
+      <LABEL index="11" value="11" />
+      <LABEL index="12" value="12" />
+      <LABEL index="13" value="13" />
+      <LABEL index="14" value="14" />
+      <LABEL index="15" value="15" />
+      <LABEL index="16" value="16" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xDD6C" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5D7B" flags="0x30">
+    <title>B3605 - Commanded Fuel When in Open Loop (Normal)</title>
+    <description>When the engine is in Cold Open Loop Mode, this is the Commanded Fuel (EQ Ratio).&#013;&#010;&#013;&#010;Column headings = ECT (F)&#013;&#010;Row headings = MAP</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MAP (kPa)</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="20" />
+      <LABEL index="1" value="25" />
+      <LABEL index="2" value="30" />
+      <LABEL index="3" value="35" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="45" />
+      <LABEL index="6" value="50" />
+      <LABEL index="7" value="55" />
+      <LABEL index="8" value="60" />
+      <LABEL index="9" value="65" />
+      <LABEL index="10" value="70" />
+      <LABEL index="11" value="75" />
+      <LABEL index="12" value="80" />
+      <LABEL index="13" value="85" />
+      <LABEL index="14" value="90" />
+      <LABEL index="15" value="95" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xC92A" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x1D97" flags="0xC">
+    <title>B3608 - Delay Before Entering PE Mode</title>
+    <description>Once Power Enrichment conditions are met, they must exist for this long (seconds) before Power Enrichment Mode is entered.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xDD0C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x1502" flags="0x30">
+    <title>B3609 - PE Delay Counter Adjustment (Seconds)</title>
+    <description>Used to adjust how fast (seconds) Power Enrichment (PE) Mode becomes active at different RPMs.&#013;&#010;&#013;&#010;Column headings = TPS (%)&#013;&#010;Row headings = RPM</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="10" />
+      <LABEL index="2" value="20" />
+      <LABEL index="3" value="30" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="60" />
+      <LABEL index="7" value="70" />
+      <LABEL index="8" value="80" />
+      <LABEL index="9" value="90" />
+      <LABEL index="10" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>15</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xDBC2" mmedelementsizebits="16" mmedrowcount="15" mmedcolcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x569C" flags="0xC">
+    <title>B3610 - PE Delay RPM Bypass</title>
+    <description>Bypass the Power Enrichment Delay if above this RPM.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xDD0E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x315D" flags="0xC">
+    <title>B3611 - PE Delay Coolant Temp Bypass (Upper)</title>
+    <description>If Engine Coolant Temperature (ECT) is above this value, bypass Power Enrichment delay.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xDD14" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7CC5" flags="0xC">
+    <title>B3612 - PE Delay Coolant Temp Bypass (Lower)</title>
+    <description>If Engine Coolant Temperature (ECT) is below this value, bypass Power Enrichment delay.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xDD16" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x233B" flags="0xC">
+    <title>B3613 - PE MAP Threshold</title>
+    <description>When the Manifold Absolute Pressure (MAP) is above this value (kPa), then Power Enrichment Mode can be enabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC868" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MAP (kPa)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x56D6" flags="0xC">
+    <title>B3614 - Hot PE Mode Coolant Temp Threshold</title>
+    <description>If the Engine Coolant Temperature (ECT) is above this value, then the Power Enrichment Hot Mode table will be used.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC862" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x5FC5" flags="0x30">
+    <title>B3615 - Hot PE Mode Enable</title>
+    <description>If the Engine Coolant Temperature (ECT) is above the Hot Engine Threshold, then these Throttle Positions (% TPS) will be used to enable Power Enrichment (PE).&#013;&#010;&#013;&#010;Also see:&#013;&#010;Hot PE Mode Coolant Temp Threshold (B3614)</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xC86C" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x101B" flags="0x30">
+    <title>B3616 - Normal PE Mode Enable</title>
+    <description>If the Engine Coolant Temperature (ECT) is below the Hot Engine Threshold, then these Throttle Positions (% TPS) will be used to enable Power Enrichment (PE).&#013;&#010;&#013;&#010;Also see:&#013;&#010;Hot PE Mode Coolant Temp Threshold (B3614)</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xC892" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7899" flags="0x30">
+    <title>B3617 - PE Modifier Base on Coolant Temp</title>
+    <description>When in Power Enrichment (PE) Mode, this value (EQ Ratio) is added to the Commanded Fuel EQ Ratio.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xC8DE" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>-2.000000</min>
+      <max>2.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/16384">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2EBE" flags="0x30">
+    <title>B3618 - PE Modifier Based on RPM</title>
+    <description>When in Power Enrichment (PE) Mode, the Commanded Fuel (EQ Ratio) will be defined by this table.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xC8B8" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x106E" flags="0xC">
+    <title>B3619 - Hot PE Mode Coolant Temp Threshold (Entry)</title>
+    <description>If Engine Coolant Temperature (ECT) reaches this value, then Hot Engine Power Enrichment Mode may become active.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC84C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3ACC" flags="0xC">
+    <title>B3620 - Hot PE Mode Coolant Temp Threshold (Exit)</title>
+    <description>If in Hot Engine Power Enrichment Mode, then the Engine Coolant Temperature (ECT) must fall below this value before Normal Power Enrichment Modes are resumed.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC84E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x67FC" flags="0xC">
+    <title>B3621 - Hot PE Mode TPS Threshold (Entry)</title>
+    <description>If the Throttle Position (% TPS) is above this value, and Engine Coolant Temperature (ECT) is above the Hot Engine Threshold, then Hot Power Enrichment Mode will become active.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC850" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x88D" flags="0xC">
+    <title>B3622 - Hot PE Mode TPS Threshold (Exit)</title>
+    <description>If Hot Power Enrichment Mode is active and Throttle Position (% TPS) falls below this value, then Power Enrichment Mode will be disabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC852" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6F42" flags="0xC">
+    <title>B3623 - Hot PE Mode MAP Threshold (Entry)</title>
+    <description>If the Manifold Absolute Pressure (MAP) is above this value, and Engine Coolant Temperature (ECT) is above the Hot Engine Threshold then, Hot Power Enrichment Mode will become active.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC854" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MAP (kPa)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3324" flags="0xC">
+    <title>B3624 - Hot PE Mode MAP Threshold (Exit)</title>
+    <description>If Hot Power Enrichment Mode is active and the Manifold Absolute Pressure (MAP) falls below this value, then Power Enrichment Mode will be disabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC856" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MAP (kPa)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1F4" flags="0xC">
+    <title>B3625 - Hot PE Mode Speed Threshold (Entry)</title>
+    <description>If the Vehicle Speed (MPH) is above this value, and Engine Coolant Temperature (ECT) is above the Hot Engine Threshold, then Hot Power Enrichment Mode will become active.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC858" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xD15" flags="0xC">
+    <title>B3626 - Hot PE Mode Speed Threshold (Exit)</title>
+    <description>If Hot Power Enrichment Mode is active and Vehicle Speed (MPH) falls below this value then Power Enrichment Mode will be disabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xC85A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x26A2" flags="0x30">
+    <title>B3629 - Park to Drive Enrichment (EQ Ratio)</title>
+    <description>Upon detecting a Park or Neutral to Drive Gear selection, this value (EQ Ratio) is added to the Open Loop Commanded Fuel EQ Ratio.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="EQ Ratio" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xD1A2" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <decimalpl>3</decimalpl>
+      <min>-31.000000</min>
+      <max>31.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6C6" flags="0x30">
+    <title>B3630 - Park to Drive Enrichment Decay Delay</title>
+    <description>Upon detecting a Park or Neutral to Drive gear selection, wait this many Engine Revolutions before Leaning out the Park or Neutral to Drive Enrichment.&#013;&#010;&#013;&#010;&#013;&#010;Also see:&#013;&#010;Park to Drive Enrichment Decay Rate (B3631)&#013;&#010;Park to Drive Enrichment Decay Factor (B3651)</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Eng. Revs</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xD084" mmedelementsizebits="8" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x47DC" flags="0x30">
+    <title>B3631 -  Park to Drive Enrichment Decay Rate</title>
+    <description>The Park or Neutral to Drive Enrichment is decayed by Park to Drive Enrichment Decay Factor (B3651) at this rate (Engine Revolutions).&#013;&#010;&#013;&#010;Higher values will cause a slower Decay Rate.&#013;&#010;Lower values will cause a faster Decay Rate.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Park to Drive Enrichment Decay Delay (B3630)&#013;&#010;Park to Drive Enrichment Decay Factor (B3651)</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Eng. Revs</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xD094" mmedelementsizebits="8" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0xF73" flags="0x30">
+    <title>B3641 - PE Modifier Based on Intake Temp</title>
+    <description>When in Power Enrichment (PE) Mode this value (EQ Ratio) is added to the Commanded Fuel EQ Ratio.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (IAT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="262" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xC904" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>-2.000000</min>
+      <max>2.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/16384">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x78B1" flags="0xC">
+    <title>B3643 - PE Commanded Fuel Step Size</title>
+    <description>As Power Enrichment (PE) Mode is transitioned in or out, this is the commanded Fuel Step Size, this value is updated approx 20 times per second.&#013;&#010;&#013;&#010;EQ Ratio example:&#013;&#010;If the target EQ Ratio is 1.2 and the step size is 0.01, it will take approximately 1 second before the commanded fuel returns to stoichiometry (EQ Ratio = 1.0).&#013;&#010;&#013;&#010;AFR example:&#013;&#010;If the target AFR is 12.0 and the step size is 0.1, it will take approximately 1.3 second before the commanded fuel returns to stoichiometry (AFR = 14.63).</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xE22C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>EQ Ratio</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>31.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/1024">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6A58" flags="0xC">
+    <title>B3644 - PE Commanded Fuel Ramp In Rate</title>
+    <description>This is the rate the PCM will transition from stoichiometry to PE Mode Commanded Fuel.&#013;&#010;&#013;&#010;Also see:&#013;&#010;PE Commanded Fuel Step Size (B3643)</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xE22E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x638F" flags="0xC">
+    <title>B3645 - PE Commanded Fuel Ramp Out Rate</title>
+    <description>This is the rate the PCM will transition back from PE Mode Commanded Fuel to stoichiometry.&#013;&#010;&#013;&#010;Also see:&#013;&#010;PE Commanded Fuel Step Size (B3643)</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xE230" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x1B3D" flags="0x30">
+    <title>B3648 - Commanded Fuel When in Open Loop (Ethanol)</title>
+    <description>When the engine is in Cold Open Loop Mode, this is the Commanded Fuel (EQ Ratio).&#013;&#010;&#013;&#010;Column headings = ECT (F)&#013;&#010;Row headings = MAP</description>
+    <CATEGORYMEM index="0" category="22" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MAP (kPa)</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="20" />
+      <LABEL index="1" value="25" />
+      <LABEL index="2" value="30" />
+      <LABEL index="3" value="35" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="45" />
+      <LABEL index="6" value="50" />
+      <LABEL index="7" value="55" />
+      <LABEL index="8" value="60" />
+      <LABEL index="9" value="65" />
+      <LABEL index="10" value="70" />
+      <LABEL index="11" value="75" />
+      <LABEL index="12" value="80" />
+      <LABEL index="13" value="85" />
+      <LABEL index="14" value="90" />
+      <LABEL index="15" value="95" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xCBB0" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x644E" flags="0x30">
+    <title>B3651 - Park to Drive Enrichment Decay Factor</title>
+    <description>The Park or Neutral to Drive Enrichment is decayed by this Factor for each Park to Drive Enrichment Decay Rate (B3631) Engine Revolutions.&#013;&#010;&#013;&#010;Values closer to 1 will cause a slower Decay of the Enrichment.&#013;&#010;Values closer to 0 will cause a faster Decay of the Enrichment.</description>
+    <CATEGORYMEM index="0" category="3" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Factor</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xD0A4" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/2048">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x1C0B" flags="0xC">
+    <title>B3652 - Piston Protection MAF Limit</title>
+    <description>If the MAF Flow Rate goes above this amount, and Piston Protection RPM Limit (B3653) and Piston Protection TPS Limit (B3654) and Piston Protection ECT Limit (B3655) are also above their limits then Piston Protection Fuelling Mode can be enabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xDD2E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Grams/sec</units>
+    <rangehigh>511.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6DF3" flags="0xC">
+    <title>B3653 - Piston Protection RPM Limit</title>
+    <description>If the RPM goes above this amount, and Piston Protection MAF Limit (B3652) and Piston Protection TPS Limit (B3654) and Piston Protection ECT Limit (B3655) are also above their limits then Piston Protection Fuelling Mode can be enabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xDD30" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6FEA" flags="0xC">
+    <title>B3654 - Piston Protection TPS Limit</title>
+    <description>If the Throttle Position (% TPS) goes above this amount, and Piston Protection MAF Limit (B3652) and Piston Protection RPM Limit (B3653) and Piston Protection ECT Limit (B3655) are also above their limits then Piston Protection Fuelling Mode can be enabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xDD32" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4849" flags="0xC">
+    <title>B3655 - Piston Protection ECT Limit</title>
+    <description>If the Engine Coolant Temperature (ECT) goes above this amount, and Piston Protection MAF Limit (B3652) and Piston Protection RPM Limit (B3653) and Piston Protection TPS Limit (B3654) are also above their limits then Piston Protection Fuelling Mode can be enabled.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xDD26" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x355B" flags="0xC">
+    <title>B3656 - Piston Protection Timer</title>
+    <description>Once Piston Protection MAF Limit (B3652) and Piston Protection RPM Limit (B3653) and Piston Protection TPS Limit (B3654) and Piston Protection ECT Limit (B3655) are all above their limits, they must remain above those limits for this long (seconds) before Piston Protection Fuelling will begin adding extra fuel.</description>
+    <CATEGORYMEM index="0" category="5" />
+    <EMBEDDEDDATA mmedaddress="0xDD28" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x3B19" flags="0x30">
+    <title>B3659 - Commanded Fuel When in Piston Protection Mode (EQ Ratio)</title>
+    <description>This is the Commanded Fuel (EQ Ratio) once the PCM enters Piston Protection Mode.  Piston Protection Mode will become active under sustained heavy load conditions.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Piston Protection MAF Limit (B3652)&#013;&#010;Piston Protection RPM Limit (B3653)&#013;&#010;Piston Protection TPS Limit (B3654)&#013;&#010;Piston Protection ECT Limit (B3655)</description>
+    <CATEGORYMEM index="0" category="5" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xDD38" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2FF9" flags="0x30">
+    <title>B3660 - Open Loop Ethanol Blend Factor</title>
+    <description>Blends B3605 - Commanded Fuel When in Open Loop (Normal), and B3648 - Commanded Fuel When in Open Loop (Ethanol) - based on % Ethanol content in the fuel being used.</description>
+    <CATEGORYMEM index="0" category="22" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Factor</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Ethanol</units>
+      <indexcount>5</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="10" />
+      <LABEL index="2" value="20" />
+      <LABEL index="3" value="50" />
+      <LABEL index="4" value="80" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xC7F6" mmedelementsizebits="16" mmedrowcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0002441406">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1330" flags="0x30">
+    <title>B3701 - Injector Pulse Width Voltage Adjustment</title>
+    <description>As Battery Voltage varies, the Injector Pulse Widths (IPW) are adjusted by this value (milliseconds), to compensate for the changes in the opening and closing times.&#013;&#010;&#013;&#010;Column headings = MAP&#013;&#010;Row headings = Volts (Battery)</description>
+    <CATEGORYMEM index="0" category="6" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MAP (kPa)</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="05" />
+      <LABEL index="2" value="10" />
+      <LABEL index="3" value="15" />
+      <LABEL index="4" value="20" />
+      <LABEL index="5" value="25" />
+      <LABEL index="6" value="30" />
+      <LABEL index="7" value="35" />
+      <LABEL index="8" value="40" />
+      <LABEL index="9" value="45" />
+      <LABEL index="10" value="50" />
+      <LABEL index="11" value="55" />
+      <LABEL index="12" value="60" />
+      <LABEL index="13" value="65" />
+      <LABEL index="14" value="70" />
+      <LABEL index="15" value="75" />
+      <LABEL index="16" value="80" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Volts</units>
+      <indexcount>28</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="4.50" />
+      <LABEL index="1" value="5.00" />
+      <LABEL index="2" value="5.50" />
+      <LABEL index="3" value="6.00" />
+      <LABEL index="4" value="6.50" />
+      <LABEL index="5" value="7.00" />
+      <LABEL index="6" value="7.50" />
+      <LABEL index="7" value="8.00" />
+      <LABEL index="8" value="8.50" />
+      <LABEL index="9" value="9.00" />
+      <LABEL index="10" value="9.50" />
+      <LABEL index="11" value="10.00" />
+      <LABEL index="12" value="10.50" />
+      <LABEL index="13" value="11.00" />
+      <LABEL index="14" value="11.50" />
+      <LABEL index="15" value="12.00" />
+      <LABEL index="16" value="12.50" />
+      <LABEL index="17" value="13.00" />
+      <LABEL index="18" value="13.50" />
+      <LABEL index="19" value="14.00" />
+      <LABEL index="20" value="14.50" />
+      <LABEL index="21" value="15.00" />
+      <LABEL index="22" value="15.50" />
+      <LABEL index="23" value="16.00" />
+      <LABEL index="24" value="16.50" />
+      <LABEL index="25" value="17.00" />
+      <LABEL index="26" value="17.50" />
+      <LABEL index="27" value="18.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xE2E0" mmedelementsizebits="16" mmedrowcount="28" mmedcolcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/65.8">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x718A" flags="0x30">
+    <title>B3704 - Injector Bank Assignments</title>
+    <description>Assigns each Injector output to Bank 1 or Bank 2, of the Engine.&#013;&#010;&#013;&#010;0 = Bank 1&#013;&#010;1 = Bank 2&#013;&#010;2 = None (i.e. the particular Injector Assignment is not in use)</description>
+    <CATEGORYMEM index="0" category="6" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Bank</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Injector</units>
+      <indexcount>8</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="A" />
+      <LABEL index="1" value="B" />
+      <LABEL index="2" value="C" />
+      <LABEL index="3" value="D" />
+      <LABEL index="4" value="E" />
+      <LABEL index="5" value="F" />
+      <LABEL index="6" value="G" />
+      <LABEL index="7" value="H" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xE6B8" mmedelementsizebits="8" mmedrowcount="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>2.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFFLAG uniqueid="0x4862">
+    <title>B3801 - Long Term Fuel Trim (LTFT) Correction</title>
+    <description>Unchecked = Disable LTFT&#013;&#010;&#013;&#010;Checked = Enable LTFT</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xE7EC" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x7410" flags="0xC">
+    <title>B3802 - Minimum Coolant Temp to Enable LTFT</title>
+    <description>Once Engine Coolant Temperature (ECT) is above this value (Deg F), the Long Term Fuel Trim (LTFT) Learning will be Enabled.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xE7E8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7726" flags="0xC">
+    <title>B3803 - Maximum Coolant Temp to Enable LTFT</title>
+    <description>Once Engine Coolant Temperature (ECT) is above this value (Deg F), the Long Term Fuel Trim (LTFT) Learning will be Disabled.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xE7EA" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x73D3" flags="0xC">
+    <title>B3805 - LTFT Minimum Correction</title>
+    <description>Lower Limit to which the Long Term Fuel Trim (LTFT) will adjust.&#013;&#010;&#013;&#010;eg.:&#013;&#010;0.9 = -10%&#013;&#010;0.8 = -20%&#013;&#010;0.75 = -25%</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xE7F2" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Factor</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>1.990000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0004882813">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x28AF" flags="0xC">
+    <title>B3806 - LTFT Maximum Correction</title>
+    <description>Upper Limit to which the Long Term Fuel Trim (LTFT) will adjust.&#013;&#010;&#013;&#010;eg.:&#013;&#010;1.1 = +10%&#013;&#010;1.2 = +20%&#013;&#010;1.25 = +25%</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xE7F8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Factor</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>1.990000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0004882813">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x13B2" flags="0xC">
+    <title>B3807 - Maximum TPS (%) for Idle LTFT</title>
+    <description>Maximum throttle (%) allowed for Long Term Fuel Trim (LTFT) idle adjustment.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xE78E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% </units>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x64AA" flags="0xC">
+    <title>B3808 - Maximum Speed for Idle LTFT</title>
+    <description>Maximum vehicle speed allowed for Long Term Fuel Trim (LTFT) idle adjustment.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xE790" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x3D2D" flags="0x30">
+    <title>B3809 - RPM Boundaries for LTFT Cells</title>
+    <description>Defines the RPM boundaries for the Long Term Fuel Trim (LTFT) cells.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Boundary</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Low" />
+      <LABEL index="1" value="Mid" />
+      <LABEL index="2" value="High" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xE792" mmedelementsizebits="16" mmedrowcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6C01" flags="0x30">
+    <title>B3810 - MAP Boundaries for LTFT Cells (kPa)</title>
+    <description>Defines the Manifold Absolute Pressure (MAP) boundaries for the Long Term Fuel Trim (LTFT) cells.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>kPa</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Boundary</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Low" />
+      <LABEL index="1" value="Mid" />
+      <LABEL index="2" value="High" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xE798" mmedelementsizebits="16" mmedrowcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>105.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7517" flags="0x30">
+    <title>B4001 - Injector Flow Rate (Grams/sec)</title>
+    <description>Flow Rate (grams per second) of the Fuel Injectors.  If the Fuel Rail Pressure is NOT referenced to Manifold Pressure (Returnless style), then decreasing the Manifold Pressure has the same effect as increasing the Fuel Rail Pressure. The Fuel Flow Rate of the Injectors will increase at higher Manifold Vacuums (i.e. lower Manifold Pressure).&#013;&#010;&#013;&#010;This table calibrates the Flow Rate of the Injectors at various Manifold Vacuum levels.  It is based on Manifold Absolute VACUUM (MAV), where:&#013;&#010;&#013;&#010;0 kPa of Manifold Vacuum is normal atmospheric pressure&#013;&#010;&#013;&#010;80 kPa of Manifold Vacuum is normal atmospheric pressure minus 80 kPa, which at sea level equates to 101.3 - 80.0 = 21.3 kPa MAP.</description>
+    <CATEGORYMEM index="0" category="6" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>kPa Vacuum</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="05" />
+      <LABEL index="2" value="10" />
+      <LABEL index="3" value="15" />
+      <LABEL index="4" value="20" />
+      <LABEL index="5" value="25" />
+      <LABEL index="6" value="30" />
+      <LABEL index="7" value="35" />
+      <LABEL index="8" value="40" />
+      <LABEL index="9" value="45" />
+      <LABEL index="10" value="50" />
+      <LABEL index="11" value="55" />
+      <LABEL index="12" value="60" />
+      <LABEL index="13" value="65" />
+      <LABEL index="14" value="70" />
+      <LABEL index="15" value="75" />
+      <LABEL index="16" value="80" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xE96C" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>511.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/128">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7F04" flags="0x30">
+    <title>B4002 - Injector Voltage Correction</title>
+    <description>Injector Flow compensation based on Fuel Pump Voltage.</description>
+    <CATEGORYMEM index="0" category="6" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Factor</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>FP Voltage</units>
+      <indexcount>28</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="4.50" />
+      <LABEL index="1" value="5.00" />
+      <LABEL index="2" value="5.50" />
+      <LABEL index="3" value="6.00" />
+      <LABEL index="4" value="6.50" />
+      <LABEL index="5" value="7.00" />
+      <LABEL index="6" value="7.50" />
+      <LABEL index="7" value="8.00" />
+      <LABEL index="8" value="8.50" />
+      <LABEL index="9" value="9.00" />
+      <LABEL index="10" value="9.50" />
+      <LABEL index="11" value="10.00" />
+      <LABEL index="12" value="10.50" />
+      <LABEL index="13" value="11.00" />
+      <LABEL index="14" value="11.50" />
+      <LABEL index="15" value="12.00" />
+      <LABEL index="16" value="12.50" />
+      <LABEL index="17" value="13.00" />
+      <LABEL index="18" value="13.50" />
+      <LABEL index="19" value="14.00" />
+      <LABEL index="20" value="14.50" />
+      <LABEL index="21" value="15.00" />
+      <LABEL index="22" value="15.50" />
+      <LABEL index="23" value="16.00" />
+      <LABEL index="24" value="16.50" />
+      <LABEL index="25" value="17.00" />
+      <LABEL index="26" value="17.50" />
+      <LABEL index="27" value="18.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xE98E" mmedelementsizebits="16" mmedrowcount="28" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>8.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7EF5" flags="0x30">
+    <title>B4003 - Minimum Injector Pulse Width (Milliseconds)</title>
+    <description>This is the Minimum Injector Pulse Width (milliseconds) the PCM can command for a given RPM.</description>
+    <CATEGORYMEM index="0" category="6" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Milliseconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEA4E" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/65.8">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0xE6F" flags="0x30">
+    <title>B4004 - Defaullt Minimum Injector Pulse Width (Milliseconds)</title>
+    <description>If the PCM commands a Injector Pulse, which is less than Minimum Injector Pulse Width (B4003), then the Injector Pulse Times (milliseconds) from this table will be used instead.</description>
+    <CATEGORYMEM index="0" category="6" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Milliseconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEA78" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/65.8">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x4C2B" flags="0xC">
+    <title>B4006 - Small Pulse Threshold (Milliseconds)</title>
+    <description>If the Commanded Injector on time is less than this value (milliseconds) the PCM assumes this to be a Small Pulse.</description>
+    <CATEGORYMEM index="0" category="6" />
+    <EMBEDDEDDATA mmedaddress="0xE9C6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Milliseconds</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/65.8">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1713" flags="0xC">
+    <title>B4101 - Closed Loop Idle Vehicle Speed</title>
+    <description>Vehicle speed must be below this value for closed loop idle fuelling control to occur.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xEAC0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2E60" flags="0xC">
+    <title>B4103 - Closed Loop Idle Throttle Position</title>
+    <description>Throttle position (%) must be below this value for closed loop idle fuelling control to occur.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xEABC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>%</units>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x413D" flags="0x30">
+    <title>B4105 - O2 Switch Point (mV)</title>
+    <description>Voltage (mV) at which the O2 switches from Rich to Lean or from Lean to Rich.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>mV</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Bank 1" />
+      <LABEL index="1" value="Bank 2" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Mode</units>
+      <indexcount>9</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Mode 0" />
+      <LABEL index="1" value="Mode 8" />
+      <LABEL index="2" value="Mode 16" />
+      <LABEL index="3" value="Mode 24" />
+      <LABEL index="4" value="Mode 32" />
+      <LABEL index="5" value="Mode 40" />
+      <LABEL index="6" value="Mode 48" />
+      <LABEL index="7" value="Mode 56" />
+      <LABEL index="8" value="Mode 64" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xEBF8" mmedelementsizebits="16" mmedrowcount="9" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>1110.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/29.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x35E" flags="0x30">
+    <title>B4106 - LTFT Update Filter (Factor)</title>
+    <description>Determines the weighting of the adjustment applied to the Long Term Fuel Trim (LTFT) when it is updated.&#013;&#010;&#013;&#010;Larger values mean each update carries more &quot;weight&quot; and has a larger effect on the LTFT.&#013;&#010;&#013;&#010;Smaller values mean each update carries less &quot;weight&quot; and has a smaller effect on the LTFT.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Factor</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Bank 1" />
+      <LABEL index="1" value="Bank 2" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Mode</units>
+      <indexcount>9</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Mode 0" />
+      <LABEL index="1" value="Mode 8" />
+      <LABEL index="2" value="Mode 16" />
+      <LABEL index="3" value="Mode 24" />
+      <LABEL index="4" value="Mode 32" />
+      <LABEL index="5" value="Mode 40" />
+      <LABEL index="6" value="Mode 48" />
+      <LABEL index="7" value="Mode 56" />
+      <LABEL index="8" value="Mode 64" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xECC8" mmedelementsizebits="8" mmedrowcount="9" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="16" />
+      <units>Factor</units>
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>0.996000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x47B0" flags="0x30">
+    <title>B4113 - STFT Base Delay</title>
+    <description>Determines the rate (seconds) at which the STFT is updated by the PCM.&#013;&#010;&#013;&#010;These values are further adjusted by the multipliers in STFT Delay Multiplier (B4114).&#013;&#010;&#013;&#010;The O2 sensor voltages provide the PCM with the raw Rich or Lean data that it uses to periodically adjust the Short Term Fuel Trims (STFT).&#013;&#010;&#013;&#010;Even though the O2 sensors are sampled by the PCM up to 80 times per second, the Short Term Fuel Trim (STFT) is computed and updated by the PCM at varying rates.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Lean" />
+      <LABEL index="1" value="Rich" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Mode</units>
+      <indexcount>9</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Mode 0" />
+      <LABEL index="1" value="Mode 8" />
+      <LABEL index="2" value="Mode 16" />
+      <LABEL index="3" value="Mode 24" />
+      <LABEL index="4" value="Mode 32" />
+      <LABEL index="5" value="Mode 40" />
+      <LABEL index="6" value="Mode 48" />
+      <LABEL index="7" value="Mode 56" />
+      <LABEL index="8" value="Mode 64" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xEB6E" mmedelementsizebits="16" mmedrowcount="9" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x531B" flags="0x30">
+    <title>B4114 - STFT Delay Multiplier</title>
+    <description>These values are the multipliers applied to STFT Base Delay (B4113).  Based on the magnitude of the difference between the O2 millivolts and the O2 Switch Point (B4105).&#013;&#010;&#013;&#010;The O2 sensor voltages provide the PCM with the raw Rich or Lean data that it uses to periodically adjust the Short Term Fuel Trims (STFT).&#013;&#010;&#013;&#010;Even though the O2 sensors are sampled by the PCM up to 80 times per second, the Short Term Fuel Trim (STFT) is computed and updated by the PCM at varying rates.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Lean" />
+      <LABEL index="1" value="Rich" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>mV</units>
+      <indexcount>13</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="35" />
+      <LABEL index="2" value="70" />
+      <LABEL index="3" value="104" />
+      <LABEL index="4" value="138" />
+      <LABEL index="5" value="173" />
+      <LABEL index="6" value="208" />
+      <LABEL index="7" value="242" />
+      <LABEL index="8" value="277" />
+      <LABEL index="9" value="311" />
+      <LABEL index="10" value="346" />
+      <LABEL index="11" value="380" />
+      <LABEL index="12" value="415" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xEB92" mmedelementsizebits="16" mmedrowcount="13" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>2.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/2048">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0xF4D" flags="0xC">
+    <title>B4115 - STFT Maximum Correction</title>
+    <description>The maximum value to which the STFT can be corrected.&#013;&#010;&#013;&#010;Examples:&#013;&#010;1.1 = +10%&#013;&#010;1.2 = +20%&#013;&#010;1.25 = +25%</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xEBCC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Factor</units>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/2048">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7ED1" flags="0xC">
+    <title>B4116 - STFT Minimum Correction</title>
+    <description>The minimum value to which the STFT can be corrected.&#013;&#010;&#013;&#010;Examples:&#013;&#010;0.9 = -10%&#013;&#010;0.8 = -20%&#013;&#010;0.75 = -25%</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xEBC8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Factor</units>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/2048">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xDE" flags="0xC">
+    <title>B4117 - STFT Multiplier</title>
+    <description>The final multiplier that is applied to the STFT Correction.&#013;&#010;&#013;&#010;This multiplier is applied for both Idle and non-Idle conditions, but only if the fuel system is in Closed Loop.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xECC6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Multiplier</units>
+    <decimalpl>6</decimalpl>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/2048">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x64D" flags="0xC">
+    <title>B4118 - STFT Adjustment at Idle</title>
+    <description>When idling, this value is ADDED to the STFT if both STFT and LTFT are LEAN.&#013;&#010;&#013;&#010;When idling, this value is SUBTRACTED from the STFT if both STFT and LTFT are RICH.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xEBC6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Rate</units>
+    <decimalpl>6</decimalpl>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/2048">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x635E" flags="0xC">
+    <title>B4201 - CLosed Loop Cold Temp (F)</title>
+    <description>If the startup Engine Coolant Temperature (ECT) is less than this, then the PCM will run the Closed Loop Cold Engine Timer (B4202) before allowing Closed Loop.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xED10" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7245" flags="0xC">
+    <title>B4202 - Closed Loop Cold Engine Timer</title>
+    <description>If the engine is deemed to be running in Cold Mode, then this amount of time (seconds) must elapse before Closed Loop can occur.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xED14" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xB69" flags="0xC">
+    <title>B4203 - Closed Loop Normal Temp (F)</title>
+    <description>If the startup the Engine Coolant Temp (ECT) is above this value, then the PCM will run the Closed Loop Normal Temp Timer (B4204) before allowing Closed Loop.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xED12" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x597A" flags="0xC">
+    <title>B4204 - Closed Loop Normal Temp Timer</title>
+    <description>If the engine is deemed to be running in Normal Temp Mode, then this amount of time (seconds) must elapse before Closed Loop can occur.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xED18" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFFLAG uniqueid="0x3A79">
+    <title>B4206 - Use O2 with Open Loop Commanded Fuel Table</title>
+    <description>Unchecked = O2 trim will begin once Closed Loop Temp Enable (B4205) has been reached.&#013;&#010;&#013;&#010;Checked = O2 trim will begin as soon as the O2 sensors are ready.</description>
+    <CATEGORYMEM index="0" category="7" />
+    <EMBEDDEDDATA mmedaddress="0xED40" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x577F" flags="0xC">
+    <title>B4301 - Fan #1 IAC Correction</title>
+    <description>Amount of increased IAC airflow (grams/sec) applied to compensate for the electrical load of Radiator Cooling Fan #1.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xED4E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Grams/sec</units>
+    <rangehigh>25.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/1024">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4CE5" flags="0xC">
+    <title>B4302 - Fan #2 IAC Correction</title>
+    <description>Amount of increased IAC airflow (grams/sec) applied to compensate for the electrical load of Radiator Cooling Fan #2.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xED50" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Grams/sec</units>
+    <rangehigh>25.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/1024">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x1FC8" flags="0x30">
+    <title>B4205 - Closed Loop Temp Enable</title>
+    <description>Defines the Engine Coolant Temp (ECT) threshold for Closed Loop fuelling (i.e. O2 fuel trim).  Once the ECT is above these values, Closed Loop can occur.&#013;&#010;&#013;&#010;The table is referenced to Intake Air Temp (IAT).</description>
+    <CATEGORYMEM index="0" category="7" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (IAT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xED1A" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>-39.000000</min>
+      <max>283.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="(X*0.0703125)+32">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4E16" flags="0x30">
+    <title>B4304 - Startup Airflow Correction</title>
+    <description>Correction to Airflow on startup - referenced to Engine Coolant Temperature (ECT). This value is added to Startup Friction Airflow Correction (B4343) for a final airflow correction value on startup.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Startup Airflow Delay (B4342)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-04" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="68" />
+      <LABEL index="4" value="104" />
+      <LABEL index="5" value="140" />
+      <LABEL index="6" value="176" />
+      <LABEL index="7" value="212" />
+      <LABEL index="8" value="248" />
+      <LABEL index="9" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEFBE" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2C81" flags="0x30">
+    <title>B4307 - Desired Airflow (grams/sec)</title>
+    <description>Used to reduce Airflow as the engine warms up - referenced to Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;While primarily used to configure the Idle Airflow, this parameter also controls the Base Airflow for Non-Idle conditions.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="In Gear" />
+      <LABEL index="1" value="In P/N" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F</units>
+      <indexcount>16</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F -40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF04C" mmedelementsizebits="16" mmedrowcount="16" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6939" flags="0x30">
+    <title>B4308 - Airflow Parked</title>
+    <description>When the IAC Motor is in the Parked position this is the required Airflow.  The IAC will be moved to the Parked position in situations like engine shutdown and key on.&#013;&#010;&#013;&#010;This table is referenced to Intake Air Temperature (IAT).</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (IAT)</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-04" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="68" />
+      <LABEL index="4" value="104" />
+      <LABEL index="5" value="140" />
+      <LABEL index="6" value="176" />
+      <LABEL index="7" value="212" />
+      <LABEL index="8" value="248" />
+      <LABEL index="9" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEF20" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x48DA" flags="0x30">
+    <title>B4309 - Throttle Cracker Airflow in Gear (grams/sec)</title>
+    <description>Airflow values added to Idle Airflow when the Throttle Cracker function is active and the transmission is in Gear.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Vehicle Speed (MPH)&#013;&#010;&#013;&#010;If both the Throttle Cracker Airflow and the Throttle Follower Airflow are non zero, then the sum of both Airflows is added to the Idle Airflow.&#013;&#010;&#013;&#010;The table references Vehicle Speed (MPH) and RPM.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Cracker Activate Speed (B4311)&#013;&#010;Throttle Cracker Deactivate Speed (B4312)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>12</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="1000" />
+      <LABEL index="2" value="1600" />
+      <LABEL index="3" value="2200" />
+      <LABEL index="4" value="2800" />
+      <LABEL index="5" value="3400" />
+      <LABEL index="6" value="4000" />
+      <LABEL index="7" value="4600" />
+      <LABEL index="8" value="5200" />
+      <LABEL index="9" value="5800" />
+      <LABEL index="10" value="6400" />
+      <LABEL index="11" value="7000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="04" />
+      <LABEL index="2" value="08" />
+      <LABEL index="3" value="12" />
+      <LABEL index="4" value="16" />
+      <LABEL index="5" value="20" />
+      <LABEL index="6" value="24" />
+      <LABEL index="7" value="28" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="36" />
+      <LABEL index="10" value="40" />
+      <LABEL index="11" value="44" />
+      <LABEL index="12" value="48" />
+      <LABEL index="13" value="52" />
+      <LABEL index="14" value="56" />
+      <LABEL index="15" value="60" />
+      <LABEL index="16" value="64" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF11C" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="12" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6B0D" flags="0x30">
+    <title>B4310 - Throttle Cracker Airflow in P/N (grams/sec)</title>
+    <description>Airflow values added to Idle Airflow when the Throttle Cracker function is active and the transmission is in Park or Neutral (or the clutch is depressed).&#013;&#010;&#013;&#010;If both the Throttle Cracker Airflow and the Throttle Follower Airflow are non zero, then the sum of both Airflows is added to the Idle Airflow.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Cracker Activate Speed (B4311)&#013;&#010;Throttle Cracker Deactivate Speed (B4312)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>18</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="02" />
+      <LABEL index="2" value="04" />
+      <LABEL index="3" value="06" />
+      <LABEL index="4" value="08" />
+      <LABEL index="5" value="10" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="18" />
+      <LABEL index="8" value="22" />
+      <LABEL index="9" value="26" />
+      <LABEL index="10" value="30" />
+      <LABEL index="11" value="34" />
+      <LABEL index="12" value="42" />
+      <LABEL index="13" value="50" />
+      <LABEL index="14" value="58" />
+      <LABEL index="15" value="66" />
+      <LABEL index="16" value="74" />
+      <LABEL index="17" value="82" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF3D6" mmedelementsizebits="16" mmedrowcount="18" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0xE30" flags="0xC">
+    <title>B4311 - Throttle Cracker Activate Speed</title>
+    <description>When vehicle speed exceeds this value, the Throttle Cracker function is activated.  It will remain active until the vehicle speed falls below the Throttle Cracker Deactivate Speed (B4312).</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xED48" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xEFC" flags="0xC">
+    <title>B4312 - Throttle Cracker Deactivation Speed</title>
+    <description>When vehicle speed falls below this value, the Throttle Cracker function is deactivated.  It will remain inactive until the vehicle speed exceeds Throttle Cracker Activate Speed (B4311).</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xED46" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x6C96" flags="0x30">
+    <title>B4313 - Throttle Cracker Decay Rate</title>
+    <description>When the Throttle Cracker is deactivated, the Throttle Cracker Airflow value is decayed by this amount every 100ms.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Cracker Deactivate Speed (B4312)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="04" />
+      <LABEL index="2" value="08" />
+      <LABEL index="3" value="12" />
+      <LABEL index="4" value="16" />
+      <LABEL index="5" value="20" />
+      <LABEL index="6" value="24" />
+      <LABEL index="7" value="28" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="36" />
+      <LABEL index="10" value="40" />
+      <LABEL index="11" value="44" />
+      <LABEL index="12" value="48" />
+      <LABEL index="13" value="52" />
+      <LABEL index="14" value="56" />
+      <LABEL index="15" value="60" />
+      <LABEL index="16" value="64" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEFE6" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x253C" flags="0x30">
+    <title>B4314 - Throttle Cracker Decay Delay</title>
+    <description>When the Throttle Cracker is to be deactivated, the PCM will wait this long before doing so.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Cracker Deactivate Speed (B4312)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="04" />
+      <LABEL index="2" value="08" />
+      <LABEL index="3" value="12" />
+      <LABEL index="4" value="16" />
+      <LABEL index="5" value="20" />
+      <LABEL index="6" value="24" />
+      <LABEL index="7" value="28" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="36" />
+      <LABEL index="10" value="40" />
+      <LABEL index="11" value="44" />
+      <LABEL index="12" value="48" />
+      <LABEL index="13" value="52" />
+      <LABEL index="14" value="56" />
+      <LABEL index="15" value="60" />
+      <LABEL index="16" value="64" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF008" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x565A" flags="0x30">
+    <title>B4315 - Throttle Follower Airflow</title>
+    <description>Airflow values added to Idle Airflow when the Throttle Follower function is active.  This value is multiplied by Throttle Follower Airflow RPM Multiplier (B4316) to obtain the final Throttle Follower Airflow value.&#013;&#010;&#013;&#010;If both the Throttle Cracker Airflow and the Throttle Follower Airflow are non zero, then the sum of both Airflows is added to the Idle Airflow.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower TPS change (B4321)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="0.50" />
+      <LABEL index="2" value="1.00" />
+      <LABEL index="3" value="1.50" />
+      <LABEL index="4" value="2.00" />
+      <LABEL index="5" value="2.50" />
+      <LABEL index="6" value="3.00" />
+      <LABEL index="7" value="3.50" />
+      <LABEL index="8" value="13.50" />
+      <LABEL index="9" value="23.50" />
+      <LABEL index="10" value="33.50" />
+      <LABEL index="11" value="43.50" />
+      <LABEL index="12" value="53.50" />
+      <LABEL index="13" value="63.50" />
+      <LABEL index="14" value="73.50" />
+      <LABEL index="15" value="83.50" />
+      <LABEL index="16" value="93.50" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF02A" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3129" flags="0x30">
+    <title>B4316 - Throttle Follower Airflow RPM Multiplier</title>
+    <description>The Airflow values from Throttle Follower Airflow (B4315) are multiplied by this value to obtain the final Throttle Follower Airflow value.&#013;&#010;&#013;&#010;If both the Throttle Cracker Airflow and the Throttle Follower Airflow are non zero, then the sum of both Airflows is added to the Idle Airflow.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower TPS change (B4321)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEDFC" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6B30" flags="0x30">
+    <title>B4317 - Throttle Follower Decay Rate in Gear (grams/sec)</title>
+    <description>When the transmission is in Gear, the Throttle Follower Airflow value is decayed by this amount every 12.5ms.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Vehicle Speed (MPH)&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower TPS change (B4321)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>4</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1st Gear" />
+      <LABEL index="1" value="2nd Gear" />
+      <LABEL index="2" value="3rd Gear" />
+      <LABEL index="3" value="4th Gear" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>18</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="MPH 00" />
+      <LABEL index="1" value="02" />
+      <LABEL index="2" value="04" />
+      <LABEL index="3" value="06" />
+      <LABEL index="4" value="08" />
+      <LABEL index="5" value="10" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="18" />
+      <LABEL index="8" value="22" />
+      <LABEL index="9" value="26" />
+      <LABEL index="10" value="30" />
+      <LABEL index="11" value="34" />
+      <LABEL index="12" value="42" />
+      <LABEL index="13" value="50" />
+      <LABEL index="14" value="58" />
+      <LABEL index="15" value="66" />
+      <LABEL index="16" value="74" />
+      <LABEL index="17" value="82" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF08C" mmedelementsizebits="16" mmedrowcount="18" mmedcolcount="4" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4C92" flags="0x30">
+    <title>B4318 - Throttle Follower Decay Delay in Gear</title>
+    <description>When the Throttle Follower Airflow is to be decayed and the transmission is in Gear, the PCM will wait this long before starting the decay.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower TPS change (B4321)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>18</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="02" />
+      <LABEL index="2" value="04" />
+      <LABEL index="3" value="06" />
+      <LABEL index="4" value="08" />
+      <LABEL index="5" value="10" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="18" />
+      <LABEL index="8" value="22" />
+      <LABEL index="9" value="26" />
+      <LABEL index="10" value="30" />
+      <LABEL index="11" value="34" />
+      <LABEL index="12" value="42" />
+      <LABEL index="13" value="50" />
+      <LABEL index="14" value="58" />
+      <LABEL index="15" value="66" />
+      <LABEL index="16" value="74" />
+      <LABEL index="17" value="82" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEEFC" mmedelementsizebits="16" mmedrowcount="18" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x27DB" flags="0x30">
+    <title>B4319 - Throttle Follower Decay Rate in P/N</title>
+    <description>When the transmission is in Park or Neutral (or the clutch is depressed), the Throttle Follower Airflow value is decayed by this amount every 12.5ms.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower TPS change (B4321)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>18</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="02" />
+      <LABEL index="2" value="04" />
+      <LABEL index="3" value="06" />
+      <LABEL index="4" value="08" />
+      <LABEL index="5" value="10" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="18" />
+      <LABEL index="8" value="22" />
+      <LABEL index="9" value="26" />
+      <LABEL index="10" value="30" />
+      <LABEL index="11" value="34" />
+      <LABEL index="12" value="42" />
+      <LABEL index="13" value="50" />
+      <LABEL index="14" value="58" />
+      <LABEL index="15" value="66" />
+      <LABEL index="16" value="74" />
+      <LABEL index="17" value="82" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEF34" mmedelementsizebits="16" mmedrowcount="18" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x66D8" flags="0x30">
+    <title>B4320 - Throttle Follower Decay Delay in P/N</title>
+    <description>When the Throttle Follower Airflow is to be decayed and the transmission is in Park or Neutral (or the clutch is depressed), the PCM will wait this long before starting the decay.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower TPS change (B4321)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>18</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="02" />
+      <LABEL index="2" value="04" />
+      <LABEL index="3" value="06" />
+      <LABEL index="4" value="08" />
+      <LABEL index="5" value="10" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="18" />
+      <LABEL index="8" value="22" />
+      <LABEL index="9" value="26" />
+      <LABEL index="10" value="30" />
+      <LABEL index="11" value="34" />
+      <LABEL index="12" value="42" />
+      <LABEL index="13" value="50" />
+      <LABEL index="14" value="58" />
+      <LABEL index="15" value="66" />
+      <LABEL index="16" value="74" />
+      <LABEL index="17" value="82" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEF58" mmedelementsizebits="16" mmedrowcount="18" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>409.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x6CF4" flags="0xC">
+    <title>B4321 - Throttle Follower TPS change</title>
+    <description>If the Throttle Position (%) is greater than or equal to this value, or increasing by more than this value (each 12.5ms), then the Throttle Follower airflow is added.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower Airflow (B4315)&#013;&#010;Throttle Follower Airflow RPM Multiplier (B4316)&#013;&#010;&#013;&#010;If the Throttle Position (%) is less than this value, or reducing by more than this value (each 12.5ms), then the Throttle Follower airflow is decayed out.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Throttle Follower Decay Rate in Gear (B4317)&#013;&#010;Throttle Follower Decay Delay in Gear (B4318)&#013;&#010;Throttle Follower Decay Rate in P/N (B4319)&#013;&#010;Throttle Follower Decay Delay in P/N (B4320)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xEDC0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>%</units>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x34AE" flags="0x30">
+    <title>B4332 - Rolling Idle RPM</title>
+    <description>The desired Idle Speed (RPM) when the vehicle is not stationary, and the Automatic Transmission is in Neutral, or with a Manual Transmission the Clutch is depressed.  Rolling desired Idle Mode may only be active if the Throttle Cracker is also active.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Rolling Idle Maximum TPS Position (B4335)&#013;&#010;Throttle Cracker Activate Speed (B4311)&#013;&#010;Throttle Cracker Deactivate Speed (B4312)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="10" />
+      <LABEL index="2" value="20" />
+      <LABEL index="3" value="30" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="60" />
+      <LABEL index="7" value="70" />
+      <LABEL index="8" value="80" />
+      <LABEL index="9" value="90" />
+      <LABEL index="10" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF3FA" mmedelementsizebits="16" mmedrowcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x7A36" flags="0xC">
+    <title>B4333 - Rolling Idle Disable Speed</title>
+    <description>Vehicle speed must be less than or equal to this value to disable Rolling Idle mode.  Rolling Idle mode may only be active if the Throttle Cracker is also active.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Rolling Idle Maximum TPS Position (B4335)&#013;&#010;Throttle Cracker Activate Speed (B4311)&#013;&#010;Throttle Cracker Deactivate Speed (B4312)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF308" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2B48" flags="0xC">
+    <title>B4334 - Rolling Idle Enable Speed</title>
+    <description>Vehicle speed must be greater than this value to enable Rolling Idle mode.  Rolling Idle mode may only be active if the Throttle Cracker is also active.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Rolling Idle Maximum TPS Position (B4335)&#013;&#010;Throttle Cracker Activate Speed (B4311)&#013;&#010;Throttle Cracker Deactivate Speed (B4312)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF30A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x504" flags="0xC">
+    <title>B4335 - Rolling Idle Maximum TPS Position</title>
+    <description>When in Rolling Idle mode and Throttle Position (%) is greater than this value, use the Throttle Cracker airflow instead of Rolling Idle airflow.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF30C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x827" flags="0x30">
+    <title>B4336 - Rolling Idle High Correction</title>
+    <description>Rolling Idle Airflow correction (grams/sec) when RPM is too High.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Rolling Idle Disable Speed (B4333)&#013;&#010;Rolling Idle Enable Speed (B4334)&#013;&#010;Rolling Idle Maximum TPS Position (B4335)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM Error</units>
+      <indexcount>12</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="20" />
+      <LABEL index="2" value="40" />
+      <LABEL index="3" value="60" />
+      <LABEL index="4" value="80" />
+      <LABEL index="5" value="100" />
+      <LABEL index="6" value="150" />
+      <LABEL index="7" value="200" />
+      <LABEL index="8" value="250" />
+      <LABEL index="9" value="300" />
+      <LABEL index="10" value="350" />
+      <LABEL index="11" value="400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xF448" mmedelementsizebits="16" mmedrowcount="12" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>-32.000000</min>
+      <max>32.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5372" flags="0x30">
+    <title>B4337 - Rolling Idle Low Correction</title>
+    <description>Rolling Idle Airflow correction (grams/sec) when RPM is too Low.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Rolling Idle Disable Speed (B4333)&#013;&#010;Rolling Idle Enable Speed (B4334)&#013;&#010;Rolling Idle Maximum TPS Position (B4335)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM Error</units>
+      <indexcount>12</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="20" />
+      <LABEL index="2" value="40" />
+      <LABEL index="3" value="60" />
+      <LABEL index="4" value="80" />
+      <LABEL index="5" value="100" />
+      <LABEL index="6" value="150" />
+      <LABEL index="7" value="200" />
+      <LABEL index="8" value="250" />
+      <LABEL index="9" value="300" />
+      <LABEL index="10" value="350" />
+      <LABEL index="11" value="400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xF430" mmedelementsizebits="16" mmedrowcount="12" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>-32.000000</min>
+      <max>32.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3721" flags="0x30">
+    <title>B4338 - Engine Speed Compensation (grams/sec)</title>
+    <description>Extra Airflow required to compensate for the load placed on the engine by external loads such as Initial startup, Alternator, or Heater.&#013;&#010;&#013;&#010;Column headings = In Gear or In P/N (Park or Neutral)&#013;&#010;Row headings = RPM</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="In Gear" />
+      <LABEL index="1" value="In P/N" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>12</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="RPM 0" />
+      <LABEL index="1" value="20" />
+      <LABEL index="2" value="40" />
+      <LABEL index="3" value="60" />
+      <LABEL index="4" value="80" />
+      <LABEL index="5" value="100" />
+      <LABEL index="6" value="150" />
+      <LABEL index="7" value="200" />
+      <LABEL index="8" value="250" />
+      <LABEL index="9" value="300" />
+      <LABEL index="10" value="350" />
+      <LABEL index="11" value="400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF366" mmedelementsizebits="16" mmedrowcount="12" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x394" flags="0x30">
+    <title>B4339 - Engine Speed Compensation Multiplier</title>
+    <description>This table is a Multiplier (Factor) for the Engine Speed Compensation (B4338) table.  It may be used to modify the Engine Speed Compensation (grams/sec) at various Engine Coolant Temperatures (ECT).&#013;&#010;&#013;&#010;Column headings = In Gear or In P/N (Park or Neutral)&#013;&#010;Row headings = ECT (F)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="In Gear" />
+      <LABEL index="1" value="In P/N" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF396" mmedelementsizebits="16" mmedrowcount="16" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>1.990000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/2048">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7A39" flags="0x30">
+    <title>B4342 - Startup Airflow Delay (Camshaft Revolutions)</title>
+    <description>Startup Idle Airflow Correction begins to decay after this many Camshaft Revolutions.  This parameter is referenced to Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;Also see:&#013;&#010;Startup Airflow Correction (B4304)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Cam / Revs</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-04" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="68" />
+      <LABEL index="4" value="104" />
+      <LABEL index="5" value="140" />
+      <LABEL index="6" value="176" />
+      <LABEL index="7" value="212" />
+      <LABEL index="8" value="248" />
+      <LABEL index="9" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEFD2" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>65534.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2262" flags="0x30">
+    <title>B4343 - Startup Friction Airflow Correction (ECT)</title>
+    <description>Correction to Idle Airflow on Startup to overcome initial starting friction and cold engine components - referenced to Engine Coolant Temperature (ECT).  This value is added to Startup Airflow Correction (B4304) for a final Airflow Correction value on Startup.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Startup Friction Airflow Decay (B4344)&#013;&#010;Startup Friction Airflow Delay (B4345)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEE3A" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1E1D" flags="0x30">
+    <title>B4344 - Startup Friction Airflow Decay (Crankshaft Revolutions)</title>
+    <description>Startup Friction Airflow correction is decayed by this amount, every 90 degrees of Crankshaft Rotation.  This parameter is referenced to Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;Also see:&#013;&#010;Startup Friction Airflow Correction (B4343)&#013;&#010;Startup Friction Airflow Delay (B4345)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-04" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="68" />
+      <LABEL index="4" value="104" />
+      <LABEL index="5" value="140" />
+      <LABEL index="6" value="176" />
+      <LABEL index="7" value="212" />
+      <LABEL index="8" value="248" />
+      <LABEL index="9" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEE26" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2323" flags="0x30">
+    <title>B4345 - Startup Friction Airflow Delay (Camshaft Revolutions)</title>
+    <description>Startup Friction Airflow correction begins to decay after this many Camshaft Revolutions.  This parameter is referenced to Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;Also see:&#013;&#010;Startup Friction Airflow Correction (B4343)&#013;&#010;Startup Friction Airflow Decay (B4344)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Cam / Revs</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-04" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="68" />
+      <LABEL index="4" value="104" />
+      <LABEL index="5" value="140" />
+      <LABEL index="6" value="176" />
+      <LABEL index="7" value="212" />
+      <LABEL index="8" value="248" />
+      <LABEL index="9" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEE5A" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>65534.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x79E2" flags="0xC">
+    <title>B4349 - ETC Throttle Area Conversion</title>
+    <description>Used to convert a Desired Throttle Area from square millimeters to ETC motor position.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xED44" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% per square mm</units>
+    <decimalpl>5</decimalpl>
+    <rangehigh>1.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.00001525879">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3EC0" flags="0xC">
+    <title>B4350 - Maximum Desired Idle Area</title>
+    <description>This calibration limits the Desired Idle Effective Area.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xED7A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Square mm</units>
+    <rangehigh>2048.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.03125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x6BA8" flags="0x30">
+    <title>B4354 - A/C Airflow Ramp In (grams/sec)</title>
+    <description>Used to Ramp In the IAC Airflow Compensation for the torque load when the A/C Compressor Clutch is engaged.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Ft-lbs</units>
+      <indexcount>14</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="04" />
+      <LABEL index="2" value="08" />
+      <LABEL index="3" value="12" />
+      <LABEL index="4" value="16" />
+      <LABEL index="5" value="20" />
+      <LABEL index="6" value="24" />
+      <LABEL index="7" value="28" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="36" />
+      <LABEL index="10" value="40" />
+      <LABEL index="11" value="44" />
+      <LABEL index="12" value="48" />
+      <LABEL index="13" value="52" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xED86" mmedelementsizebits="16" mmedrowcount="14" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x280F" flags="0x30">
+    <title>B4355 - A/C Airflow Ramp Out (grams/sec)</title>
+    <description>Used to Ramp Out the IAC Airflow Compensation for the torque load when the A/C Compressor Clutch is disengaged.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Ft-lbs</units>
+      <indexcount>14</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="04" />
+      <LABEL index="2" value="08" />
+      <LABEL index="3" value="12" />
+      <LABEL index="4" value="16" />
+      <LABEL index="5" value="20" />
+      <LABEL index="6" value="24" />
+      <LABEL index="7" value="28" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="36" />
+      <LABEL index="10" value="40" />
+      <LABEL index="11" value="44" />
+      <LABEL index="12" value="48" />
+      <LABEL index="13" value="52" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xEDA2" mmedelementsizebits="16" mmedrowcount="14" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x62E6" flags="0xC">
+    <title>B4401 - Default IAC Motor Park Position</title>
+    <description>The is the Default Park Position (in steps) for the IAC Motor, if the IAC has been reset and a new rest position has not been learned.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF4BC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Steps</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>400.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4825" flags="0xC">
+    <title>B4402 - Maximum IAC Steps</title>
+    <description>The Maximum number of Steps to which the IAC Motor can extend.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF4BE" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Steps</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>400.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x4987" flags="0x30">
+    <title>B4403 - IAC Effective Area (Steps)</title>
+    <description>Used to convert Effective Area (which the PCM calculates from the Idle Airflow) into IAC Motor Steps.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Steps</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Square mm</units>
+      <indexcount>61</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="02" />
+      <LABEL index="2" value="04" />
+      <LABEL index="3" value="06" />
+      <LABEL index="4" value="08" />
+      <LABEL index="5" value="10" />
+      <LABEL index="6" value="12" />
+      <LABEL index="7" value="14" />
+      <LABEL index="8" value="16" />
+      <LABEL index="9" value="18" />
+      <LABEL index="10" value="20" />
+      <LABEL index="11" value="22" />
+      <LABEL index="12" value="24" />
+      <LABEL index="13" value="26" />
+      <LABEL index="14" value="28" />
+      <LABEL index="15" value="30" />
+      <LABEL index="16" value="32" />
+      <LABEL index="17" value="34" />
+      <LABEL index="18" value="36" />
+      <LABEL index="19" value="38" />
+      <LABEL index="20" value="40" />
+      <LABEL index="21" value="42" />
+      <LABEL index="22" value="44" />
+      <LABEL index="23" value="46" />
+      <LABEL index="24" value="48" />
+      <LABEL index="25" value="50" />
+      <LABEL index="26" value="52" />
+      <LABEL index="27" value="54" />
+      <LABEL index="28" value="56" />
+      <LABEL index="29" value="58" />
+      <LABEL index="30" value="60" />
+      <LABEL index="31" value="62" />
+      <LABEL index="32" value="64" />
+      <LABEL index="33" value="66" />
+      <LABEL index="34" value="68" />
+      <LABEL index="35" value="70" />
+      <LABEL index="36" value="72" />
+      <LABEL index="37" value="74" />
+      <LABEL index="38" value="76" />
+      <LABEL index="39" value="78" />
+      <LABEL index="40" value="80" />
+      <LABEL index="41" value="82" />
+      <LABEL index="42" value="84" />
+      <LABEL index="43" value="86" />
+      <LABEL index="44" value="88" />
+      <LABEL index="45" value="90" />
+      <LABEL index="46" value="92" />
+      <LABEL index="47" value="94" />
+      <LABEL index="48" value="96" />
+      <LABEL index="49" value="98" />
+      <LABEL index="50" value="100" />
+      <LABEL index="51" value="102" />
+      <LABEL index="52" value="104" />
+      <LABEL index="53" value="106" />
+      <LABEL index="54" value="108" />
+      <LABEL index="55" value="110" />
+      <LABEL index="56" value="112" />
+      <LABEL index="57" value="114" />
+      <LABEL index="58" value="116" />
+      <LABEL index="59" value="118" />
+      <LABEL index="60" value="120" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF4CC" mmedelementsizebits="16" mmedrowcount="61" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>400.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x77A5" flags="0xC">
+    <title>B4501 - Idle Learn Minimum Temperature (F)</title>
+    <description>If the Engine Coolant Temperature (ECT) is below this value then Idle Airflow Learning will be Disabled.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Idle Learn Maximum Temperature (B4502)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xF568" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x692C" flags="0xC">
+    <title>B4502 - Idle Learn Maximum Temperature (F)</title>
+    <description>If the Engine Coolant Temperature (ECT) is above this value, then Idle Airflow Learning will be Disabled.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Idle Learn Minimum Temperature (B4501)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xF566" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x291E" flags="0xC">
+    <title>B4509 - Airflow Direct Speed Control Threshold (RPM)</title>
+    <description>If absolute Engine Speed Error (RPM) is greater than this value, then Airflow Direct Speed Control is Enabled.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF6C0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7068" flags="0xC">
+    <title>B4510 - Airflow Control Startup Delay</title>
+    <description>Delays the Airflow Control until the engine has been running for this many seconds.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF6C6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x47F6" flags="0x30">
+    <title>B4512 - Filtered RPM Airflow Correction (grams/sec)</title>
+    <description>Airflow Correction to be applied based on RPM Rate of Change which attempts to dampen overshoot of the Desired RPM.&#013;&#010;&#013;&#010;Column headings = RPM Increasing (+ RPM) or RPM Decreasing (- RPM)&#013;&#010;Row headings = RPM Rate of Change&#013;&#010;&#013;&#010;If RPM is increasing (+ RPM) the value in this calibration is subtracted from the Airflow.  If RPM is decreasing (- RPM) the value in this calibration is added to the Airflow.&#013;&#010;&#013;&#010;The Rate of Change of the Engine RPM is a ratio of two, filtered RPM followers. One is weakly filtered and tracks the RPM closely, the other is strongly filtered and lags the RPM.&#013;&#010;&#013;&#010;Rate of Change values closer to 0.00 indicate that the engine speed is changing slowly.  Rate of Change values closer to 0.15 indicate that the engine speed is changing quickly.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="+ RPM" />
+      <LABEL index="1" value="- RPM" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM Rate</units>
+      <indexcount>10</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="0.01" />
+      <LABEL index="2" value="0.03" />
+      <LABEL index="3" value="0.04" />
+      <LABEL index="4" value="0.05" />
+      <LABEL index="5" value="0.06" />
+      <LABEL index="6" value="0.08" />
+      <LABEL index="7" value="0.09" />
+      <LABEL index="8" value="0.10" />
+      <LABEL index="9" value="0.15" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF5A8" mmedelementsizebits="16" mmedrowcount="10" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/128">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x65EE" flags="0x30">
+    <title>B4514 - Learned Airflow Correction (grams/sec)</title>
+    <description>Correction to Learned Airflow when Engine Speed is too High or too Low and transmission is in Gear or Park/Neutral (P/N).  This table is referenced to Absolute RPM Error (the Row headings).&#013;&#010;&#013;&#010;Absolute RPM error is the difference between current Engine Speed and desired Engine Speed.&#013;&#010;&#013;&#010;Manual transmission vehicles are assumed to be in Gear unless the clutch is depressed.&#013;&#010;&#013;&#010;Column Headings:&#013;&#010;+RPM-G = RPM High in Gear&#013;&#010;+RPM-P = RPM High in P/N&#013;&#010;-RPM-G = RPM Low in Gear&#013;&#010;-RPM-P = RPM Low in P/N</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>4</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="+RPM-G" />
+      <LABEL index="1" value="+RPM-P" />
+      <LABEL index="2" value="-RPM-G" />
+      <LABEL index="3" value="-RPM-P" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM Error</units>
+      <indexcount>12</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="20" />
+      <LABEL index="2" value="40" />
+      <LABEL index="3" value="60" />
+      <LABEL index="4" value="80" />
+      <LABEL index="5" value="100" />
+      <LABEL index="6" value="150" />
+      <LABEL index="7" value="200" />
+      <LABEL index="8" value="250" />
+      <LABEL index="9" value="300" />
+      <LABEL index="10" value="350" />
+      <LABEL index="11" value="400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF5D0" mmedelementsizebits="16" mmedrowcount="12" mmedcolcount="4" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>30.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4197" flags="0x30">
+    <title>B4515 - Direct Airflow Correction (grams/sec)</title>
+    <description>Correction to Direct Airflow when Engine Speed is too High or too Low under various transmission and A/C conditions.  This table is referenced to Absolute RPM Error (the Row headings).&#013;&#010;&#013;&#010;Absolute RPM Error is the difference between current Engine Speed and desired Engine Speed.&#013;&#010;&#013;&#010;Manual transmission vehicles are assumed to be in Gear unless the clutch is depressed.&#013;&#010;&#013;&#010;Column headings:&#013;&#010;+Gear = RPM High in Gear&#013;&#010;+G-AC = RPM High in Gear, with A/C on&#013;&#010;+P/N = RPM High in P/N&#013;&#010;-Gear = RPM Low in Gear&#013;&#010;-G-AC = RPM Low in Gear, with A/C on&#013;&#010;-P/N = RPM Low in P/N</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>6</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>3</datatype>
+      <unittype>11</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="+Gear" />
+      <LABEL index="1" value="+G-AC" />
+      <LABEL index="2" value="+P/N" />
+      <LABEL index="3" value="-Gear" />
+      <LABEL index="4" value="-G-AC" />
+      <LABEL index="5" value="-P/N" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM Error</units>
+      <indexcount>12</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="20" />
+      <LABEL index="2" value="40" />
+      <LABEL index="3" value="60" />
+      <LABEL index="4" value="80" />
+      <LABEL index="5" value="100" />
+      <LABEL index="6" value="150" />
+      <LABEL index="7" value="200" />
+      <LABEL index="8" value="250" />
+      <LABEL index="9" value="300" />
+      <LABEL index="10" value="350" />
+      <LABEL index="11" value="400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF630" mmedelementsizebits="16" mmedrowcount="12" mmedcolcount="6" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/128">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x435D" flags="0x30">
+    <title>B4521 - Maximum Idle Short Term Correction</title>
+    <description>This is the Maximum Correction the Short Term Idle Learn may adjust.&#013;&#010;&#013;&#010;This parameter is referenced to Engine Coolant Temperature (ECT).</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-04" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="68" />
+      <LABEL index="4" value="104" />
+      <LABEL index="5" value="140" />
+      <LABEL index="6" value="176" />
+      <LABEL index="7" value="212" />
+      <LABEL index="8" value="248" />
+      <LABEL index="9" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF4A8" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>63.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/1024">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6459" flags="0x30">
+    <title>B4522 - Stall Saver RPM</title>
+    <description>Engine Speed must fall below the table value to initiate Stall Saver Mode.&#013;&#010;&#013;&#010;Column headings = in Gear or in P/N (Park or Neutral)&#013;&#010;Row headings = RPM&#013;&#010;&#013;&#010;As an example, if the column value is 500 RPM and the Stall Speed is set to 400 RPM, then if the Target Idle Speed is 500 RPM but the actual Engine Speed is less than 400 RPM then Stall Saver will become active.&#013;&#010;&#013;&#010;This parameter is referenced to RPM.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Gear" />
+      <LABEL index="1" value="P/N" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Idle RPM</units>
+      <indexcount>12</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="500" />
+      <LABEL index="2" value="600" />
+      <LABEL index="3" value="700" />
+      <LABEL index="4" value="800" />
+      <LABEL index="5" value="900" />
+      <LABEL index="6" value="1000" />
+      <LABEL index="7" value="1100" />
+      <LABEL index="8" value="1200" />
+      <LABEL index="9" value="1300" />
+      <LABEL index="10" value="1400" />
+      <LABEL index="11" value="1500" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF576" mmedelementsizebits="16" mmedrowcount="12" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x6D9C" flags="0xC">
+    <title>B4601 - Max Idle RPM in Gear</title>
+    <description>Maximum Idle RPM that the PCM may attempt to command when in Gear.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF6E0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1954" flags="0xC">
+    <title>B4602 - Max Idle RPM in P/N</title>
+    <description>Maximum Idle RPM that the PCM may attempt to command when in Park or Neutral.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF7EA" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x166F" flags="0x30">
+    <title>B4603 - Desired Idle Speeds</title>
+    <description>Desired Idle Speeds.  Based on various Transmission and Air Conditioner combinations.  This parameter is referenced to Engine Coolant Temperature (ECT) - which are the Row headings.&#013;&#010;&#013;&#010;Column headings:&#013;&#010;G-AC-N = In Gear, with A/C off&#013;&#010;G-AC-Y = In Gear, with A/C on&#013;&#010;P-AC-N = In P/N, with A/C off&#013;&#010;P-AC-Y = In P/N, with A/C on</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>4</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="G-AC-N" />
+      <LABEL index="1" value="G-AC-Y" />
+      <LABEL index="2" value="P-AC-N" />
+      <LABEL index="3" value="P-AC-Y" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F -40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF702" mmedelementsizebits="16" mmedrowcount="16" mmedcolcount="4" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3CA3" flags="0x30">
+    <title>B4604 - Startup RPM Offset</title>
+    <description>Upon engine Startup this is the RPM Offset which is added to the values in Desired Idle Speeds (B4603).  This parameter is referenced to Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;Column headings = in Gear or in P/N (Park or Neutral)&#013;&#010;Row headings = ECT (F)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Gear" />
+      <LABEL index="1" value="P/N" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>10</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F -40" />
+      <LABEL index="1" value="-04" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="68" />
+      <LABEL index="4" value="104" />
+      <LABEL index="5" value="140" />
+      <LABEL index="6" value="176" />
+      <LABEL index="7" value="212" />
+      <LABEL index="8" value="248" />
+      <LABEL index="9" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF7C2" mmedelementsizebits="16" mmedrowcount="10" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4C7C" flags="0x30">
+    <title>B4605 - Heater Warmup RPM Offset</title>
+    <description>In an attempt to get the engine hotter faster and increase the heater temperature this is the RPM Offset which is added to the values in Desired Idle Speeds (B4603).  This parameter is referenced to Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;Column headings = in P/N (Park or Neutral) or in Gear&#013;&#010;Row headings = ECT (F)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="P/N" />
+      <LABEL index="1" value="Gear" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>16</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F -40" />
+      <LABEL index="1" value="-18" />
+      <LABEL index="2" value="03" />
+      <LABEL index="3" value="25" />
+      <LABEL index="4" value="46" />
+      <LABEL index="5" value="68" />
+      <LABEL index="6" value="90" />
+      <LABEL index="7" value="111" />
+      <LABEL index="8" value="133" />
+      <LABEL index="9" value="154" />
+      <LABEL index="10" value="176" />
+      <LABEL index="11" value="198" />
+      <LABEL index="12" value="219" />
+      <LABEL index="13" value="241" />
+      <LABEL index="14" value="262" />
+      <LABEL index="15" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0xF782" mmedelementsizebits="16" mmedrowcount="16" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x7A9C" flags="0xC">
+    <title>B4612 - RPM Set Point Adjust in Gear</title>
+    <description>This the RPM adjustment that will be made if the actual engine RPM is too high/low from the Target Idle RPM in gear.&#013;&#010;&#013;&#010;Also see:&#013;&#010;RPM Set Point Adjust in P/N (B4613)&#013;&#010;RPM Set Point Adjust Timer (B4614)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF6F6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>50.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x772" flags="0xC">
+    <title>B4613 - RPM Set Point Adjust in P/N</title>
+    <description>This the RPM adjustment that will be made if the actual engine RPM is too high/low from the Target Idle RPM in P/N.&#013;&#010;&#013;&#010;Also see:&#013;&#010;RPM Set Point Adjust in Gear (B4612)&#013;&#010;RPM Set Point Adjust Timer (B4614)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF6F8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>50.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6529" flags="0xC">
+    <title>B4614 - RPM Set Point Adjust Timer</title>
+    <description>Amount of time (seconds) that must elapse before the next Set Point Adjustment will be made.&#013;&#010;&#013;&#010;Also see:&#013;&#010;RPM Set Point Adjust in Gear (B4612)&#013;&#010;RPM Set Point Adjust in P/N (B4613)</description>
+    <CATEGORYMEM index="0" category="10" />
+    <EMBEDDEDDATA mmedaddress="0xF6F4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x64BA" flags="0x30">
+    <title>B5001 - MAF Sensor Calibration</title>
+    <description>This table defines the MAF measured Air Flow Rates (grams per second) versus the Frequency Output (Hz) to the PCM.</description>
+    <CATEGORYMEM index="0" category="2" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Hz</units>
+      <indexcount>85</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1500" />
+      <LABEL index="1" value="1625" />
+      <LABEL index="2" value="1750" />
+      <LABEL index="3" value="1875" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2125" />
+      <LABEL index="6" value="2250" />
+      <LABEL index="7" value="2375" />
+      <LABEL index="8" value="2500" />
+      <LABEL index="9" value="2625" />
+      <LABEL index="10" value="2750" />
+      <LABEL index="11" value="2875" />
+      <LABEL index="12" value="3000" />
+      <LABEL index="13" value="3125" />
+      <LABEL index="14" value="3250" />
+      <LABEL index="15" value="3375" />
+      <LABEL index="16" value="3500" />
+      <LABEL index="17" value="3625" />
+      <LABEL index="18" value="3750" />
+      <LABEL index="19" value="3875" />
+      <LABEL index="20" value="4000" />
+      <LABEL index="21" value="4125" />
+      <LABEL index="22" value="4250" />
+      <LABEL index="23" value="4375" />
+      <LABEL index="24" value="4500" />
+      <LABEL index="25" value="4625" />
+      <LABEL index="26" value="4750" />
+      <LABEL index="27" value="4875" />
+      <LABEL index="28" value="5000" />
+      <LABEL index="29" value="5125" />
+      <LABEL index="30" value="5250" />
+      <LABEL index="31" value="5375" />
+      <LABEL index="32" value="5500" />
+      <LABEL index="33" value="5625" />
+      <LABEL index="34" value="5750" />
+      <LABEL index="35" value="5875" />
+      <LABEL index="36" value="6000" />
+      <LABEL index="37" value="6125" />
+      <LABEL index="38" value="6250" />
+      <LABEL index="39" value="6375" />
+      <LABEL index="40" value="6500" />
+      <LABEL index="41" value="6625" />
+      <LABEL index="42" value="6750" />
+      <LABEL index="43" value="6875" />
+      <LABEL index="44" value="7000" />
+      <LABEL index="45" value="7125" />
+      <LABEL index="46" value="7250" />
+      <LABEL index="47" value="7375" />
+      <LABEL index="48" value="7500" />
+      <LABEL index="49" value="7625" />
+      <LABEL index="50" value="7750" />
+      <LABEL index="51" value="7875" />
+      <LABEL index="52" value="8000" />
+      <LABEL index="53" value="8125" />
+      <LABEL index="54" value="8250" />
+      <LABEL index="55" value="8375" />
+      <LABEL index="56" value="8500" />
+      <LABEL index="57" value="8625" />
+      <LABEL index="58" value="8750" />
+      <LABEL index="59" value="8875" />
+      <LABEL index="60" value="9000" />
+      <LABEL index="61" value="9125" />
+      <LABEL index="62" value="9250" />
+      <LABEL index="63" value="9375" />
+      <LABEL index="64" value="9500" />
+      <LABEL index="65" value="9625" />
+      <LABEL index="66" value="9750" />
+      <LABEL index="67" value="9875" />
+      <LABEL index="68" value="10000" />
+      <LABEL index="69" value="10125" />
+      <LABEL index="70" value="10250" />
+      <LABEL index="71" value="10375" />
+      <LABEL index="72" value="10500" />
+      <LABEL index="73" value="10625" />
+      <LABEL index="74" value="10750" />
+      <LABEL index="75" value="10875" />
+      <LABEL index="76" value="11000" />
+      <LABEL index="77" value="11125" />
+      <LABEL index="78" value="11250" />
+      <LABEL index="79" value="11375" />
+      <LABEL index="80" value="11500" />
+      <LABEL index="81" value="11625" />
+      <LABEL index="82" value="11750" />
+      <LABEL index="83" value="11875" />
+      <LABEL index="84" value="12000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0xF85A" mmedelementsizebits="16" mmedrowcount="85" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>511.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/128">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2B30" flags="0x30">
+    <title>B5401 - ETC Controlled RPM Limit</title>
+    <description>This table configures the Electronic Throttle Control (ETC) Rev Limiter&#013;&#010;&#013;&#010;*** This is the main Rev Limiter for Drive-By-Wire vehicles***</description>
+    <CATEGORYMEM index="0" category="9" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>10</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1st" />
+      <LABEL index="1" value="2nd" />
+      <LABEL index="2" value="3rd" />
+      <LABEL index="3" value="4th" />
+      <LABEL index="4" value="5th" />
+      <LABEL index="5" value="6th" />
+      <LABEL index="6" value="7th" />
+      <LABEL index="7" value="8th" />
+      <LABEL index="8" value="P/N" />
+      <LABEL index="9" value="Reverse" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x9A82" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>12799.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/5.12">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7850" flags="0x30">
+    <title>B5901 - Catalytic Converter Light-off (Degrees)</title>
+    <description>Spark Retard to assist in Catalytic Converter Light-off on startup.&#013;&#010;&#013;&#010;Columns headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="200" />
+      <LABEL index="2" value="400" />
+      <LABEL index="3" value="600" />
+      <LABEL index="4" value="800" />
+      <LABEL index="5" value="1000" />
+      <LABEL index="6" value="1200" />
+      <LABEL index="7" value="1400" />
+      <LABEL index="8" value="1600" />
+      <LABEL index="9" value="1800" />
+      <LABEL index="10" value="2000" />
+      <LABEL index="11" value="2200" />
+      <LABEL index="12" value="2400" />
+      <LABEL index="13" value="2600" />
+      <LABEL index="14" value="2800" />
+      <LABEL index="15" value="3000" />
+      <LABEL index="16" value="3200" />
+      <LABEL index="17" value="3400" />
+      <LABEL index="18" value="3600" />
+      <LABEL index="19" value="3800" />
+      <LABEL index="20" value="4000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x10176" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5E81" flags="0x30">
+    <title>B5902 - Catalytic Converter Light-off Temp Multiplier</title>
+    <description>Multiplier for the Catalytic Converter Light-off table.&#013;&#010;&#013;&#010;This parameter is referenced to Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;e.g.:&#013;&#010;0.0 = No Correction applied from Catalytic Converter Light-off spark table.&#013;&#010;1.0 = Use the full value defined in Catalytic Converter Light-off spark table.&#013;&#010;0.5 = Use 50% of the value defined in Catalytic Converter Light-off spark table.</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x13D06" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>2.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x4359" flags="0xC">
+    <title>B5905 - Catalytic Converter Light-off Vacuum Disable</title>
+    <description>Maximum Manifold Vacuum (MAP) to allow Catalytic Converter Light-off spark correction.</description>
+    <CATEGORYMEM index="0" category="11" />
+    <EMBEDDEDDATA mmedaddress="0x13CB4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>kPa</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x5BB2" flags="0xC">
+    <title>B5906 - Catalytic Converter Light-off Vacuum Enable</title>
+    <description>Minimum Manifold Vacuum (MAP) to allow Catalytic Converter Light-off after being Disabled by going above the Maximum.</description>
+    <CATEGORYMEM index="0" category="11" />
+    <EMBEDDEDDATA mmedaddress="0x13CB6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>kPa</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x6121" flags="0x30">
+    <title>B5907 - EGR Spark Correction (Degrees)</title>
+    <description>Spark Correction for when EGR is active.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>13</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x118B6" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="13" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6DBB" flags="0x30">
+    <title>B5908 - Fuel Mixture Spark Correction (Degrees)</title>
+    <description>Provides Fuel Mixture Correction to Spark Timing.&#013;&#010;&#013;&#010;Column headings = Fuel Mixture Equivalence Ratio (EQ Ratio or EQR)&#013;&#010;Row Headings = RPM</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>EQ Ratio</units>
+      <indexcount>16</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.80" />
+      <LABEL index="1" value="0.85" />
+      <LABEL index="2" value="0.90" />
+      <LABEL index="3" value="0.95" />
+      <LABEL index="4" value="1.00" />
+      <LABEL index="5" value="1.05" />
+      <LABEL index="6" value="1.10" />
+      <LABEL index="7" value="1.15" />
+      <LABEL index="8" value="1.20" />
+      <LABEL index="9" value="1.25" />
+      <LABEL index="10" value="1.30" />
+      <LABEL index="11" value="1.35" />
+      <LABEL index="12" value="1.40" />
+      <LABEL index="13" value="1.45" />
+      <LABEL index="14" value="1.50" />
+      <LABEL index="15" value="1.55" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x11616" mmedelementsizebits="16" mmedrowcount="21" mmedcolcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1CF4" flags="0x30">
+    <title>B5909 - Spark Timing when Cranking</title>
+    <description>Spark Advance commanded when engine is Cranking.&#013;&#010;&#013;&#010;This parameter is referenced to Engine Coolant Temperature (ECT).</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x13774" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1BD5" flags="0x30">
+    <title>B5910 - Spark ECT Table (Degrees)</title>
+    <description>Provides Engine Coolant Temperature (ECT) correction to Spark Timing.&#013;&#010;&#013;&#010;Column headings = ECT (F)&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>37</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-31" />
+      <LABEL index="2" value="-22" />
+      <LABEL index="3" value="-13" />
+      <LABEL index="4" value="-04" />
+      <LABEL index="5" value="05" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="23" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="41" />
+      <LABEL index="10" value="50" />
+      <LABEL index="11" value="59" />
+      <LABEL index="12" value="68" />
+      <LABEL index="13" value="77" />
+      <LABEL index="14" value="86" />
+      <LABEL index="15" value="95" />
+      <LABEL index="16" value="104" />
+      <LABEL index="17" value="113" />
+      <LABEL index="18" value="122" />
+      <LABEL index="19" value="131" />
+      <LABEL index="20" value="140" />
+      <LABEL index="21" value="149" />
+      <LABEL index="22" value="158" />
+      <LABEL index="23" value="167" />
+      <LABEL index="24" value="176" />
+      <LABEL index="25" value="185" />
+      <LABEL index="26" value="194" />
+      <LABEL index="27" value="203" />
+      <LABEL index="28" value="212" />
+      <LABEL index="29" value="221" />
+      <LABEL index="30" value="230" />
+      <LABEL index="31" value="239" />
+      <LABEL index="32" value="248" />
+      <LABEL index="33" value="257" />
+      <LABEL index="34" value="266" />
+      <LABEL index="35" value="275" />
+      <LABEL index="36" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1273E" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="37" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5699" flags="0x30">
+    <title>B5911 - Spark IAT Table (Degrees)</title>
+    <description>Spark Advance compensation provided based on Intake Air Temperature (IAT).&#013;&#010;&#013;&#010;Column headings = IAT (F)&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (IAT)</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="14" />
+      <LABEL index="1" value="23" />
+      <LABEL index="2" value="32" />
+      <LABEL index="3" value="41" />
+      <LABEL index="4" value="50" />
+      <LABEL index="5" value="59" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="77" />
+      <LABEL index="8" value="86" />
+      <LABEL index="9" value="95" />
+      <LABEL index="10" value="104" />
+      <LABEL index="11" value="113" />
+      <LABEL index="12" value="122" />
+      <LABEL index="13" value="131" />
+      <LABEL index="14" value="140" />
+      <LABEL index="15" value="149" />
+      <LABEL index="16" value="158" />
+      <LABEL index="17" value="167" />
+      <LABEL index="18" value="176" />
+      <LABEL index="19" value="185" />
+      <LABEL index="20" value="194" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/Cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x11BA8" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6B8E" flags="0x30">
+    <title>B5912 - Engine Protection Mode Timing (Degrees)</title>
+    <description>Timing values (Spark Advance) used if the PCM is operating in Engine Protection Mode.</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x13002" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3311" flags="0x30">
+    <title>B5913 - Spark High-Octane Table (Degrees)</title>
+    <description>Defines the upper timing when good fuel, with adequate octane is being used, and the engine is not in an Idle condition.&#013;&#010;The PCM interpolates between the High Octane Table and the Low Octane Table values based on Knock activity.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Spark Low-Octane Table (B5914)&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>25</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="600" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1000" />
+      <LABEL index="4" value="1200" />
+      <LABEL index="5" value="1400" />
+      <LABEL index="6" value="1600" />
+      <LABEL index="7" value="1800" />
+      <LABEL index="8" value="2000" />
+      <LABEL index="9" value="2200" />
+      <LABEL index="10" value="2400" />
+      <LABEL index="11" value="2800" />
+      <LABEL index="12" value="3200" />
+      <LABEL index="13" value="3600" />
+      <LABEL index="14" value="4000" />
+      <LABEL index="15" value="4400" />
+      <LABEL index="16" value="4800" />
+      <LABEL index="17" value="5200" />
+      <LABEL index="18" value="5600" />
+      <LABEL index="19" value="6000" />
+      <LABEL index="20" value="6400" />
+      <LABEL index="21" value="6800" />
+      <LABEL index="22" value="7200" />
+      <LABEL index="23" value="7600" />
+      <LABEL index="24" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/Cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x10890" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="25" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>60.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x53F6" flags="0x30">
+    <title>B5914 - Spark Low-Octane Table (Degrees)</title>
+    <description>Defines the lower timing when Low Octane fuel is being used or excessive Knock is detected.  The PCM interpolates between the High Octane Table and the Low Octane Table values based on Knock activity.&#013;&#010;&#013;&#010;*** The Low Octane Table will be used exclusively when a MAF DTC (i.e. when running MAFless in Speed Density mode) or a Knock Sensor DTC has been set. ***&#013;&#010;&#013;&#010;Also see:&#013;&#010;Spark High-Octane Table (B5913)&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>25</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="600" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1000" />
+      <LABEL index="4" value="1200" />
+      <LABEL index="5" value="1400" />
+      <LABEL index="6" value="1600" />
+      <LABEL index="7" value="1800" />
+      <LABEL index="8" value="2000" />
+      <LABEL index="9" value="2200" />
+      <LABEL index="10" value="2400" />
+      <LABEL index="11" value="2800" />
+      <LABEL index="12" value="3200" />
+      <LABEL index="13" value="3600" />
+      <LABEL index="14" value="4000" />
+      <LABEL index="15" value="4400" />
+      <LABEL index="16" value="4800" />
+      <LABEL index="17" value="5200" />
+      <LABEL index="18" value="5600" />
+      <LABEL index="19" value="6000" />
+      <LABEL index="20" value="6400" />
+      <LABEL index="21" value="6800" />
+      <LABEL index="22" value="7200" />
+      <LABEL index="23" value="7600" />
+      <LABEL index="24" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/Cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x10E3A" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="25" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>60.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6C50" flags="0x30">
+    <title>B5915 - Minimum Spark Advance (Degrees)</title>
+    <description>This is the Minimum Spark Timing that may be commanded.  The PCM will not allow Spark Advance to be reduced below this value.</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x11414" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4C55" flags="0x30">
+    <title>B5919 - Optimal Timing (Degrees)</title>
+    <description>This table is used as a reference for what would be best Timing, which is then used for various Torque calculations.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>20</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1200" />
+      <LABEL index="3" value="1600" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2400" />
+      <LABEL index="6" value="2800" />
+      <LABEL index="7" value="3200" />
+      <LABEL index="8" value="3600" />
+      <LABEL index="9" value="4000" />
+      <LABEL index="10" value="4400" />
+      <LABEL index="11" value="4800" />
+      <LABEL index="12" value="5200" />
+      <LABEL index="13" value="5600" />
+      <LABEL index="14" value="6000" />
+      <LABEL index="15" value="6400" />
+      <LABEL index="16" value="6800" />
+      <LABEL index="17" value="7200" />
+      <LABEL index="18" value="7600" />
+      <LABEL index="19" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>15</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.16" />
+      <LABEL index="2" value="0.24" />
+      <LABEL index="3" value="0.32" />
+      <LABEL index="4" value="0.40" />
+      <LABEL index="5" value="0.48" />
+      <LABEL index="6" value="0.56" />
+      <LABEL index="7" value="0.64" />
+      <LABEL index="8" value="0.72" />
+      <LABEL index="9" value="0.80" />
+      <LABEL index="10" value="0.88" />
+      <LABEL index="11" value="0.96" />
+      <LABEL index="12" value="1.04" />
+      <LABEL index="13" value="1.12" />
+      <LABEL index="14" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x10638" mmedelementsizebits="16" mmedrowcount="15" mmedcolcount="20" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1378" flags="0x30">
+    <title>Ethanol Optimal Timing Correction (Degrees)</title>
+    <description>This table is used to alter (correct) the Optimal Timing Table (B5919), when Ethanol (E85) is being used as Fuel.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="22" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>18</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1200" />
+      <LABEL index="3" value="1600" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2400" />
+      <LABEL index="6" value="2800" />
+      <LABEL index="7" value="3200" />
+      <LABEL index="8" value="3600" />
+      <LABEL index="9" value="4000" />
+      <LABEL index="10" value="4400" />
+      <LABEL index="11" value="4800" />
+      <LABEL index="12" value="5200" />
+      <LABEL index="13" value="5600" />
+      <LABEL index="14" value="6000" />
+      <LABEL index="15" value="6400" />
+      <LABEL index="16" value="6800" />
+      <LABEL index="17" value="7200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>11</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x13B18" mmedelementsizebits="16" mmedrowcount="11" mmedcolcount="18" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFFLAG uniqueid="0x3972">
+    <title>B5920 - Spark Smoothing Enable</title>
+    <description>Applies only to Manual Transmission calibrations.&#013;&#010;&#013;&#010;Unchecked = Disabled&#013;&#010;&#013;&#010;Checked = Enabled</description>
+    <CATEGORYMEM index="0" category="11" />
+    <EMBEDDEDDATA mmedaddress="0x12FAE" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFTABLE uniqueid="0x7C30" flags="0x30">
+    <title>B5932 - Base Spark in Gear (Degrees)</title>
+    <description>Base Timing used when the Throttle is CLOSED and the vehicle is in Gear.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>13</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1215A" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="13" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7CB" flags="0x30">
+    <title>B5933 - Base Spark in Park or Neutral (Degrees)</title>
+    <description>Base Timing used when the Throttle is CLOSED and the vehicle is in Park or Neutral.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>13</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>29</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <LABEL index="21" value="0.92" />
+      <LABEL index="22" value="0.96" />
+      <LABEL index="23" value="1.00" />
+      <LABEL index="24" value="1.04" />
+      <LABEL index="25" value="1.08" />
+      <LABEL index="26" value="1.12" />
+      <LABEL index="27" value="1.16" />
+      <LABEL index="28" value="1.20" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1244C" mmedelementsizebits="16" mmedrowcount="29" mmedcolcount="13" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3B33" flags="0x30">
+    <title>B5934 - Idle Flare Control (Degrees)</title>
+    <description>This table makes adjustments to Spark in an attempt to curb Idle Speed Flare upon Start-up.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM (Flare)</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="100" />
+      <LABEL index="2" value="200" />
+      <LABEL index="3" value="300" />
+      <LABEL index="4" value="400" />
+      <LABEL index="5" value="500" />
+      <LABEL index="6" value="600" />
+      <LABEL index="7" value="700" />
+      <LABEL index="8" value="800" />
+      <LABEL index="9" value="900" />
+      <LABEL index="10" value="1000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1379A" mmedelementsizebits="16" mmedrowcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4536" flags="0x30">
+    <title>B5935 - Idle Overspeed Error</title>
+    <description>If the actual Idle Speed is above the desired Idle Speed value, then this table is used to make adjustments to Spark Timing.  The RPM Error values are in relation to the difference between actual Idle Speed and desired Idle Speed.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM Overspeed</units>
+      <indexcount>10</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="12.50" />
+      <LABEL index="2" value="25.00" />
+      <LABEL index="3" value="37.50" />
+      <LABEL index="4" value="50.00" />
+      <LABEL index="5" value="100.00" />
+      <LABEL index="6" value="150.00" />
+      <LABEL index="7" value="200.00" />
+      <LABEL index="8" value="250.00" />
+      <LABEL index="9" value="300.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x137B0" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6E77" flags="0x30">
+    <title>B5936 - Idle Underspeed Error</title>
+    <description>If the actual Idle Speed is below the desired Idle Speed value, then this table is used to make adjustments to Spark Timing.  The RPM Error values are in relation to the difference between actual Idle Speed and desired Idle Speed.</description>
+    <CATEGORYMEM index="0" category="10" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM Underspeed</units>
+      <indexcount>10</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-300.00" />
+      <LABEL index="1" value="-250.00" />
+      <LABEL index="2" value="-200.00" />
+      <LABEL index="3" value="-150.00" />
+      <LABEL index="4" value="-100.00" />
+      <LABEL index="5" value="-50.00" />
+      <LABEL index="6" value="-37.50" />
+      <LABEL index="7" value="-25.00" />
+      <LABEL index="8" value="-12.50" />
+      <LABEL index="9" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x137C4" mmedelementsizebits="16" mmedrowcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0xC2F" flags="0x30">
+    <title>B5937 - DFCO Spark Timing, High TPS (Degrees)</title>
+    <description>Spark Timing will be lowered to these values when DFCO is active once the Fuel is cut, and TPS is above the DFCO Spark High TPS Threshold (B5938).</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xBA12" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x3B68" flags="0xC">
+    <title>B5938 - DFCO Spark High TPS Threshold</title>
+    <description>If in DFCO mode and TPS (%) is above this value, then the Timing Table shown in DFCO Spark Timing, High TPS (B5937) will be used.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBA0C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>%TPS</units>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x3EC4" flags="0x30">
+    <title>B5939 - DFCO Spark Timing, Low TPS (Degrees)</title>
+    <description>Spark Timing will be lowered to these values when DFCO is active once the Fuel is cut and TPS is below the DFCO Spark Low TPS Threshold (B5940).</description>
+    <CATEGORYMEM index="0" category="4" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0xBA3C" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x4763" flags="0xC">
+    <title>B5940 - DFCO Spark Low TPS Threshold</title>
+    <description>If in DFCO mode and TPS (%) is below this value then the Timing Table shown in DFCO Spark Timing, Low TPS (B5939) will be used.</description>
+    <CATEGORYMEM index="0" category="4" />
+    <EMBEDDEDDATA mmedaddress="0xBA0E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>%TPS</units>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x64B6" flags="0x30">
+    <title>B5943 - Spark IAT vs RPM Multiplier</title>
+    <description>This table contains Multiplier values, applied to the Spark IAT Table (B5911) based on Engine Speed.  Any value in the Spark IAT Table (B5911) will be Multiplied by this amount, before being summed in the final Spark Advance calculation.&#013;&#010;&#013;&#010;e.g.:&#013;&#010;0.0 = No Correction applied from IAT Spark Table.&#013;&#010;1.0 = Use the full value defined in IAT Spark Table.&#013;&#010;0.5 = Use 50% of the value defined in IAT Spark Table.</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x1304E" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4CE6" flags="0x30">
+    <title>B5944 - Spark IAT vs ECT Multiplier</title>
+    <description>This table contains Multiplier values, which are applied to the Spark IAT Table (B5911).  Any value in the Spark IAT Table (B5911) will be Multiplied by this amount before being summed in the final Spark Advance calculation.&#013;&#010;&#013;&#010;This table can be used to turn off IAT Spark Correction when the engine is cold (or hot).</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>37</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-31" />
+      <LABEL index="2" value="-22" />
+      <LABEL index="3" value="-13" />
+      <LABEL index="4" value="-04" />
+      <LABEL index="5" value="05" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="23" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="41" />
+      <LABEL index="10" value="50" />
+      <LABEL index="11" value="59" />
+      <LABEL index="12" value="68" />
+      <LABEL index="13" value="77" />
+      <LABEL index="14" value="86" />
+      <LABEL index="15" value="95" />
+      <LABEL index="16" value="104" />
+      <LABEL index="17" value="113" />
+      <LABEL index="18" value="122" />
+      <LABEL index="19" value="131" />
+      <LABEL index="20" value="140" />
+      <LABEL index="21" value="149" />
+      <LABEL index="22" value="158" />
+      <LABEL index="23" value="167" />
+      <LABEL index="24" value="176" />
+      <LABEL index="25" value="185" />
+      <LABEL index="26" value="194" />
+      <LABEL index="27" value="203" />
+      <LABEL index="28" value="212" />
+      <LABEL index="29" value="221" />
+      <LABEL index="30" value="230" />
+      <LABEL index="31" value="239" />
+      <LABEL index="32" value="248" />
+      <LABEL index="33" value="257" />
+      <LABEL index="34" value="266" />
+      <LABEL index="35" value="275" />
+      <LABEL index="36" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x13078" mmedelementsizebits="16" mmedrowcount="37" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x718" flags="0x30">
+    <title>B5947 - Ethanol Spark Advance Correction (Degrees)</title>
+    <description>This table is used to alter (correct) the Spark Advance, when Ethanol (E85) is being used as Fuel.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Grams/Cylinder</description>
+    <CATEGORYMEM index="0" category="22" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>18</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1200" />
+      <LABEL index="3" value="1600" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2400" />
+      <LABEL index="6" value="2800" />
+      <LABEL index="7" value="3200" />
+      <LABEL index="8" value="3600" />
+      <LABEL index="9" value="4000" />
+      <LABEL index="10" value="4400" />
+      <LABEL index="11" value="4800" />
+      <LABEL index="12" value="5200" />
+      <LABEL index="13" value="5600" />
+      <LABEL index="14" value="6000" />
+      <LABEL index="15" value="6400" />
+      <LABEL index="16" value="6800" />
+      <LABEL index="17" value="7200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/cyl</units>
+      <indexcount>21</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.08" />
+      <LABEL index="1" value="0.12" />
+      <LABEL index="2" value="0.16" />
+      <LABEL index="3" value="0.20" />
+      <LABEL index="4" value="0.24" />
+      <LABEL index="5" value="0.28" />
+      <LABEL index="6" value="0.32" />
+      <LABEL index="7" value="0.36" />
+      <LABEL index="8" value="0.40" />
+      <LABEL index="9" value="0.44" />
+      <LABEL index="10" value="0.48" />
+      <LABEL index="11" value="0.52" />
+      <LABEL index="12" value="0.56" />
+      <LABEL index="13" value="0.60" />
+      <LABEL index="14" value="0.64" />
+      <LABEL index="15" value="0.68" />
+      <LABEL index="16" value="0.72" />
+      <LABEL index="17" value="0.76" />
+      <LABEL index="18" value="0.80" />
+      <LABEL index="19" value="0.84" />
+      <LABEL index="20" value="0.88" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x13824" mmedelementsizebits="16" mmedrowcount="21" mmedcolcount="18" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <decimalpl>1</decimalpl>
+      <min>-45.000000</min>
+      <max>45.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x8DC" flags="0x30">
+    <title>B5956 - Coolant Temp Spark Multiplier</title>
+    <description>Multiplier applied to Spark ECT Table (B5910).&#013;&#010;&#013;&#010;Column headings = ECT (F)&#013;&#010;Row headings = RPM</description>
+    <CATEGORYMEM index="0" category="11" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>37</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-31" />
+      <LABEL index="2" value="-22" />
+      <LABEL index="3" value="-13" />
+      <LABEL index="4" value="-04" />
+      <LABEL index="5" value="05" />
+      <LABEL index="6" value="14" />
+      <LABEL index="7" value="23" />
+      <LABEL index="8" value="32" />
+      <LABEL index="9" value="41" />
+      <LABEL index="10" value="50" />
+      <LABEL index="11" value="59" />
+      <LABEL index="12" value="68" />
+      <LABEL index="13" value="77" />
+      <LABEL index="14" value="86" />
+      <LABEL index="15" value="95" />
+      <LABEL index="16" value="104" />
+      <LABEL index="17" value="113" />
+      <LABEL index="18" value="122" />
+      <LABEL index="19" value="131" />
+      <LABEL index="20" value="140" />
+      <LABEL index="21" value="149" />
+      <LABEL index="22" value="158" />
+      <LABEL index="23" value="167" />
+      <LABEL index="24" value="176" />
+      <LABEL index="25" value="185" />
+      <LABEL index="26" value="194" />
+      <LABEL index="27" value="203" />
+      <LABEL index="28" value="212" />
+      <LABEL index="29" value="221" />
+      <LABEL index="30" value="230" />
+      <LABEL index="31" value="239" />
+      <LABEL index="32" value="248" />
+      <LABEL index="33" value="257" />
+      <LABEL index="34" value="266" />
+      <LABEL index="35" value="275" />
+      <LABEL index="36" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="200" />
+      <LABEL index="2" value="400" />
+      <LABEL index="3" value="600" />
+      <LABEL index="4" value="800" />
+      <LABEL index="5" value="1000" />
+      <LABEL index="6" value="1200" />
+      <LABEL index="7" value="1400" />
+      <LABEL index="8" value="1600" />
+      <LABEL index="9" value="1800" />
+      <LABEL index="10" value="2000" />
+      <LABEL index="11" value="2200" />
+      <LABEL index="12" value="2400" />
+      <LABEL index="13" value="2600" />
+      <LABEL index="14" value="2800" />
+      <LABEL index="15" value="3000" />
+      <LABEL index="16" value="3200" />
+      <LABEL index="17" value="3400" />
+      <LABEL index="18" value="3600" />
+      <LABEL index="19" value="3800" />
+      <LABEL index="20" value="4000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x13162" mmedelementsizebits="16" mmedrowcount="21" mmedcolcount="37" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Deg SA</units>
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x253A" flags="0x30">
+    <title>B5948 - Burst Knock Timing (Degrees)</title>
+    <description>Burst Knock will retard or advance timing upon detection of a large change in Intake Air Mass.  If the change in Air Mass exceeds the values in the Burst Knock Delta Air Mass (B6210) table, then the values in THIS table will be ADDED or SUBTRACTED from the Final Spark value.&#013;&#010;&#013;&#010;Column headings = ECT (F)&#013;&#010;Row headings = Engine Runtime (seconds)</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Seconds</units>
+      <indexcount>7</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="20" />
+      <LABEL index="2" value="40" />
+      <LABEL index="3" value="60" />
+      <LABEL index="4" value="80" />
+      <LABEL index="5" value="100" />
+      <LABEL index="6" value="120" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x11454" mmedelementsizebits="16" mmedrowcount="7" mmedcolcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2AB7" flags="0x30">
+    <title>B5954 - Burst Knock Delta Air Mass</title>
+    <description>When a change in Cylinder Air Mass exceeds these calibrated values, then Burst Knock can be Enabled.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Burst Knock Retard (B6212)</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x1159C" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>15.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6A14" flags="0x30">
+    <title>B6202 - Knock Fast Attack Gain (Scaler)</title>
+    <description>This table sets the Gain or adjustment range of the Knock System, dependent on Engine Coolant Temperature (ECT).&#013;&#010;&#013;&#010;e.g.:&#013;&#010;To allow full knock retard adjustments, set to 1.00.&#013;&#010;To disable set to 0.00.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Scaler</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (ECT)</units>
+      <indexcount>19</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-40" />
+      <LABEL index="1" value="-22" />
+      <LABEL index="2" value="-04" />
+      <LABEL index="3" value="14" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="68" />
+      <LABEL index="7" value="86" />
+      <LABEL index="8" value="104" />
+      <LABEL index="9" value="122" />
+      <LABEL index="10" value="140" />
+      <LABEL index="11" value="158" />
+      <LABEL index="12" value="176" />
+      <LABEL index="13" value="194" />
+      <LABEL index="14" value="212" />
+      <LABEL index="15" value="230" />
+      <LABEL index="16" value="248" />
+      <LABEL index="17" value="266" />
+      <LABEL index="18" value="284" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x14910" mmedelementsizebits="16" mmedrowcount="19" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>2.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4096">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4511" flags="0x30">
+    <title>B6203 - Knock Fast Attack Rate</title>
+    <description>Once Knock is detected, the Timing will be reduced by this many Degrees per Knock Sensor Volt, every Low Resolution Reference Pulse (4x per crank rotation for V8, 3x for V6).&#013;&#010;&#013;&#010;Also see:&#013;&#010;Knock Fast Attack Gain (B6202)</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x14942" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>-0.000000</min>
+      <max>180.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0027467">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5831" flags="0x30">
+    <title>B6204 - Knock Retard Limit Not in PE Mode (Degrees)</title>
+    <description>If not in Power Enrichment (PE) Mode, then Knock can only retard the timing by these values.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MAP (kPa)</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="20" />
+      <LABEL index="1" value="25" />
+      <LABEL index="2" value="30" />
+      <LABEL index="3" value="35" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="45" />
+      <LABEL index="6" value="50" />
+      <LABEL index="7" value="55" />
+      <LABEL index="8" value="60" />
+      <LABEL index="9" value="65" />
+      <LABEL index="10" value="70" />
+      <LABEL index="11" value="75" />
+      <LABEL index="12" value="80" />
+      <LABEL index="13" value="85" />
+      <LABEL index="14" value="90" />
+      <LABEL index="15" value="95" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1496C" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2D8" flags="0x30">
+    <title>B6205 - Knock Retard Limit When in PE Mode (Degrees)</title>
+    <description>If in Power Enrichment (PE) Mode, then Knock can only retard the timing by these values.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Degrees</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1498E" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/45.5">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x1480" flags="0xC">
+    <title>B6213 - Adaptive Spark Min MAP</title>
+    <description>The Adaptive Octane Scaler cannot be modified until the Manifold Absolute Pressure (MAP) is above this value.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedaddress="0x149F4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MAP (kPa)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x708" flags="0xC">
+    <title>B6214 - Adaptive Spark Min RPM</title>
+    <description>The Adaptive Octane Scaler cannot be modified until RPM is above this value.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedaddress="0x149F8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6479" flags="0xC">
+    <title>B6215 - Adaptive Spark Max RPM</title>
+    <description>The Adaptive Octane Scaler cannot be modified if RPM is above this value.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedaddress="0x149F6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xAF2" flags="0xC">
+    <title>B6216 - Adaptive Spark Min Coolant Temp</title>
+    <description>The Adaptive Octane Scaler cannot be modified until the Engine Coolant Temp (ECT) is above this value.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x149FA" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7B7C" flags="0xC">
+    <title>B6217 - Adaptive Spark Min Intake Air Temp (IAT)</title>
+    <description>The Adaptive Octane Scaler cannot be modified until Intake Air Temperature (IAT) is above this value.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x149FC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (IAT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x55F1" flags="0xC">
+    <title>B6218 - Max Retard to Disable Learning</title>
+    <description>If Knock Retard is above this value, then further changes to the Adaptive Octane Scaler will be Disabled.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x149FE" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Degrees</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>64.000000</rangehigh>
+    <rangelow>-64.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/45.5">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3F87" flags="0xC">
+    <title>B6219 - Octane Scaler Default</title>
+    <description>If power has been removed from the PCM, then the Octane Scaler will be set to this value on power up.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedaddress="0x14A78" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Factor</units>
+    <rangehigh>1.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/4096">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x7200" flags="0x30">
+    <title>B6244 - Knock Sensor Multiplier A (Cylinder Mode)</title>
+    <description>This Multiplier is applied when not in RPM Knock Mode or TPS Knock Mode, otherwise the appropriate RPM or TPS Knock Multipliers are applied.  This value is Multiplied with the Learned Knock Threshold to determine the Knock Threshold Voltage for the current operating conditions.&#013;&#010;&#013;&#010;Higher values esensitize the Knock Sensors.&#013;&#010;Lower values Sensitize the Knock Sensors.&#013;&#010;&#013;&#010;Column headings = Cylinder Number&#013;&#010;Row headings = RPM&#013;&#010;&#013;&#010;Also see:&#013;&#010;Knock Sensor TPS Multiplier (B6250)&#013;&#010;Knock Sensor RPM Multiplier (B6255)</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Cylinder</units>
+      <indexcount>8</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Cyl 1" />
+      <LABEL index="1" value="Cyl 2" />
+      <LABEL index="2" value="Cyl 3" />
+      <LABEL index="3" value="Cyl 4" />
+      <LABEL index="4" value="Cyl 5" />
+      <LABEL index="5" value="Cyl 6" />
+      <LABEL index="6" value="Cyl 7" />
+      <LABEL index="7" value="Cyl 8" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x14E88" mmedelementsizebits="16" mmedrowcount="21" mmedcolcount="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>127.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.001953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4CFF" flags="0x30">
+    <title>B6245 - Knock Sensor Multiplier B (Cylinder Mode)</title>
+    <description>This Multiplier is always applied when Knock Detection is in Cylinder Mode.&#013;&#010;&#013;&#010;Higher values desensitize the Knock Sensors.&#013;&#010;Lower values Sensitize the Knock Sensors.&#013;&#010;&#013;&#010;Column headings = MAP (kPa)&#013;&#010;Row headings = RPM</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MAP (kPa)</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="20" />
+      <LABEL index="1" value="25" />
+      <LABEL index="2" value="30" />
+      <LABEL index="3" value="35" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="45" />
+      <LABEL index="6" value="50" />
+      <LABEL index="7" value="55" />
+      <LABEL index="8" value="60" />
+      <LABEL index="9" value="65" />
+      <LABEL index="10" value="70" />
+      <LABEL index="11" value="75" />
+      <LABEL index="12" value="80" />
+      <LABEL index="13" value="85" />
+      <LABEL index="14" value="90" />
+      <LABEL index="15" value="95" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x14FFA" mmedelementsizebits="16" mmedrowcount="21" mmedcolcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>8.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0002441406">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x73EC" flags="0x30">
+    <title>B6250 - Knock Sensor TPS Multiplier</title>
+    <description>This Multiplier is applied when in TPS Knock Mode.  TPS Knock Mode is active when all three TPS conditions are met - Minimum, Maximum, and Delta.&#013;&#010;&#013;&#010;This value is Multiplied with the Learned Knock Threshold to determine the Knock Threshold Voltage for the current operating conditions.  If both TPS Knock Mode and RPM Knock Mode are active, the highest value will be used.&#013;&#010;&#013;&#010;Higher values Desensitize the Knock Sensors.&#013;&#010;Lower values Sensitize the Knock Sensors.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x14E5E" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>127.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.001953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6C76" flags="0x30">
+    <title>B6255 - Knock Sensor RPM Multiplier</title>
+    <description>This Multiplier is applied when in RPM Knock Mode.  RPM Knock Mode is active when all three RPM conditions are met - Minimum, Maximum, and Delta.&#013;&#010;&#013;&#010;This value is Multiplied with the Learned Knock Threshold to determine the Knock Threshold Voltage for the current operating conditions.  If both TPS Knock Mode and RPM Knock Mode are active, the highest value will be used.&#013;&#010;&#013;&#010;Higher values Desensitize the Knock Sensors.&#013;&#010;Lower values Sensitize the Knock Sensors.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Multiplier</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x14E0A" mmedelementsizebits="16" mmedrowcount="21" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>127.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.001953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x6C07" flags="0xC">
+    <title>B6256 - Knock Mode Max RPM</title>
+    <description>Knock Protection will be enabled if the engine RPM is below this value.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedaddress="0x1461A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6A64" flags="0xC">
+    <title>B6257 - Knock Mode Min RPM</title>
+    <description>Knock Protection will be enabled if the engine RPM is above this value.</description>
+    <CATEGORYMEM index="0" category="12" />
+    <EMBEDDEDDATA mmedaddress="0x14618" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFFLAG uniqueid="0x7DFF">
+    <title>B6601 - Axle Torque Limiting</title>
+    <description>Used to Enable or Disable the Torque Reduction function based on Axle Torque Limits.  Typically used with 4WD trucks.&#013;&#010;&#013;&#010;Unchecked = Disabled&#013;&#010;&#013;&#010;Checked = Enabled</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedaddress="0x154FA" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFTABLE uniqueid="0xAC0" flags="0x30">
+    <title>B6605 - % Torque Loss from Spark Retard (Degrees)</title>
+    <description>Amount of Spark Retard (degrees) required to cause a Torque Lost (%) from the Traction Control System (TCS) Spark Retard.  This table tells the PCM how much Spark Retard (degrees) is required to cause a given Torque Loss / Reduction (%).&#013;&#010;&#013;&#010;Column headings = Fuel Ethanol Percentage (%)&#013;&#010;Row headings = Torque Reduction (%)</description>
+    <CATEGORYMEM index="0" category="13" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Percent</units>
+      <indexcount>5</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0%" />
+      <LABEL index="1" value="10%" />
+      <LABEL index="2" value="20%" />
+      <LABEL index="3" value="50%" />
+      <LABEL index="4" value="80%" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Torque Loss</units>
+      <indexcount>33</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0" />
+      <LABEL index="1" value="3" />
+      <LABEL index="2" value="6" />
+      <LABEL index="3" value="9" />
+      <LABEL index="4" value="12" />
+      <LABEL index="5" value="15" />
+      <LABEL index="6" value="18" />
+      <LABEL index="7" value="21" />
+      <LABEL index="8" value="25" />
+      <LABEL index="9" value="28" />
+      <LABEL index="10" value="31" />
+      <LABEL index="11" value="34" />
+      <LABEL index="12" value="37" />
+      <LABEL index="13" value="40" />
+      <LABEL index="14" value="43" />
+      <LABEL index="15" value="46" />
+      <LABEL index="16" value="50" />
+      <LABEL index="17" value="53" />
+      <LABEL index="18" value="56" />
+      <LABEL index="19" value="59" />
+      <LABEL index="20" value="62" />
+      <LABEL index="21" value="65" />
+      <LABEL index="22" value="68" />
+      <LABEL index="23" value="71" />
+      <LABEL index="24" value="75" />
+      <LABEL index="25" value="78" />
+      <LABEL index="26" value="81" />
+      <LABEL index="27" value="84" />
+      <LABEL index="28" value="87" />
+      <LABEL index="29" value="90" />
+      <LABEL index="30" value="93" />
+      <LABEL index="31" value="96" />
+      <LABEL index="32" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x153AC" mmedelementsizebits="16" mmedrowcount="33" mmedcolcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>-64.000000</min>
+      <max>64.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.021978">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x244F" flags="0x30">
+    <title>B6611 - Max Torque by Gear (Ft-lbs)</title>
+    <description>This table is used to determine the Maximum Torque (Ft-lbs) allowed by Gear. The Traction Control System (TCS) will use these values to reduce the Engine Torque.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = RPM</description>
+    <CATEGORYMEM index="0" category="13" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>10</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1st" />
+      <LABEL index="1" value="2nd" />
+      <LABEL index="2" value="3rd" />
+      <LABEL index="3" value="4th" />
+      <LABEL index="4" value="5th" />
+      <LABEL index="5" value="6th" />
+      <LABEL index="6" value="7th" />
+      <LABEL index="7" value="8th" />
+      <LABEL index="8" value="P/N" />
+      <LABEL index="9" value="Reverse" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>21</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="800" />
+      <LABEL index="3" value="1200" />
+      <LABEL index="4" value="1600" />
+      <LABEL index="5" value="2000" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2800" />
+      <LABEL index="8" value="3200" />
+      <LABEL index="9" value="3600" />
+      <LABEL index="10" value="4000" />
+      <LABEL index="11" value="4400" />
+      <LABEL index="12" value="4800" />
+      <LABEL index="13" value="5200" />
+      <LABEL index="14" value="5600" />
+      <LABEL index="15" value="6000" />
+      <LABEL index="16" value="6400" />
+      <LABEL index="17" value="6800" />
+      <LABEL index="18" value="7200" />
+      <LABEL index="19" value="7600" />
+      <LABEL index="20" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x15A8E" mmedelementsizebits="16" mmedrowcount="21" mmedcolcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>-639.000000</min>
+      <max>639.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.01953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x5F0F" flags="0xC">
+    <title>B6615 - Maximum Front Axle Torque</title>
+    <description>Maximum Torque (Ft-lbs) that the PCM will allow to the Front Axle, before attempting to reduce Engine Torque.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Axle Torque Limiting (B6601)</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedaddress="0x15596" mmedelementsizebits="32" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ft-lbs</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>41943040.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6790" flags="0xC">
+    <title>B6616 - Maximum Rear Axle Torque</title>
+    <description>Maximum Torque (Ft-lbs) that the PCM will allow to the Rear Axle, before attempting to reduce Engine Torque.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Axle Torque Limiting (B6601)</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedaddress="0x1559E" mmedelementsizebits="32" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ft-lbs</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>41943040.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x85" flags="0xC">
+    <title>B6617 - Maximum Front Driveshaft Torque</title>
+    <description>Maximum Torque (Ft-lbs) that the PCM will allow to the Front Driveshaft, before attempting to reduce Engine Torque.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Axle Torque Limiting (B6601)</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedaddress="0x1559A" mmedelementsizebits="32" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ft-lbs</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>41943040.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x17B1" flags="0xC">
+    <title>B6618 - Maximum Rear Driveshaft Torque</title>
+    <description>Maximum Torque (Ft-lbs) that the PCM will allow to the Rear Driveshaft, before attempting to reduce Engine Torque.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Axle Torque Limiting (B6601)</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedaddress="0x155A2" mmedelementsizebits="32" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ft-lbs</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>41943040.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4A3B" flags="0xC">
+    <title>B6619 - Maximum Transmission Input Torque</title>
+    <description>Maximum Torque (Ft-lbs) that the PCM will allow to the Transmission Input Shaft, before attempting to reduce Engine Torque.</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedaddress="0x1558E" mmedelementsizebits="32" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ft-lbs</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>41943040.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4307" flags="0xC">
+    <title>B6620 - Maximum Transmission Output Torque</title>
+    <description>Maximum Torque (Ft-lbs) that the PCM will allow to the Transmission Output Shaft, before attempting to reduce Engine Torque.</description>
+    <CATEGORYMEM index="0" category="13" />
+    <EMBEDDEDDATA mmedaddress="0x15592" mmedelementsizebits="32" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ft-lbs</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>41943040.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x47B4" flags="0xC">
+    <title>C2901 - MAF High Frequency Fail (Hz)</title>
+    <description>With the engine running, if the MAF Sensor Frequency (Hz) is equal to, or goes above this value (Hz), then DTC P0103 will be set.&#013;&#010;&#013;&#010;Also see:&#013;&#010;MAF High Frequency Fail Limit (C2903)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16B14" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Hz</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>20000.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7143" flags="0xC">
+    <title>C2903 - MAF High Frequency Fail Limit</title>
+    <description>With the engine running, if the MAF Sensor Frequency (Hz) is equal to, or goes above the MAF High Frequency Fail (C2901) value (Hz) this many times, then DTC P0103 will be set.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16B10" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Failures</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>65534.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1197" flags="0xC">
+    <title>C2904 - MAF Low Frequency Fail (Hz)</title>
+    <description>With the engine running, if the MAF Sensor Frequency (Hz) is equal to, or goes below this value (Hz), then DTC P0102 will be set&#013;&#010;&#013;&#010;Also see:&#013;&#010;MAF Low Frequency Fail Limit (C2906)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16B1A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Hz</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>20000.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x680C" flags="0xC">
+    <title>C2906 - MAF Low Frequency Fail Limit</title>
+    <description>With the engine running, if the MAF Sensor Frequency (Hz) is equal to, or goes below the MAF Low Frequency Fail (C2904) value (Hz) this many times, then DTC P0102 will be set.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16B16" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Failures</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>65534.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6C06" flags="0xC">
+    <title>C2907 - MAF Test Minimum RPM</title>
+    <description>The minimum Engine Speed (RPM) to run the MAF Frequency Fail (Hz) tests.&#013;&#010;&#013;&#010;Also see:&#013;&#010;MAF Low Frequency Fail (C2904)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16B54" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x499C" flags="0xC">
+    <title>C2910 - MAF Test Maximum TPS</title>
+    <description>The maximum Throttle Position (% TPS) allowed to run the MAF Frequency Fail (Hz) tests.&#013;&#010;&#013;&#010;Also see:&#013;&#010;MAF High Frequency Fail (C2901)&#013;&#010;MAF Low Frequency Fail (C2904)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16B4C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>% TPS</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>100.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/51.2">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x6077" flags="0x30">
+    <title>C2911 - MAF Rationality Test (DTC P0101 Error)</title>
+    <description>This table defines the maximum difference (grams/sec) that is allowed between the Calculated Airflow (Speed Density - based on MAP) and Actual Measured Airflow (based on MAF).&#013;&#010;&#013;&#010;If any of the individual values (Grams/sec) are exceeded by more than the allowed margin (Error - grams/sec), then P0101 will be set.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Error-gms/sec</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Grams/sec</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="40" />
+      <LABEL index="2" value="80" />
+      <LABEL index="3" value="120" />
+      <LABEL index="4" value="160" />
+      <LABEL index="5" value="200" />
+      <LABEL index="6" value="240" />
+      <LABEL index="7" value="280" />
+      <LABEL index="8" value="320" />
+      <LABEL index="9" value="360" />
+      <LABEL index="10" value="400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x16B20" mmedelementsizebits="16" mmedrowcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>0.000000</min>
+      <max>511.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0078125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x51A0" flags="0x30">
+    <title>C3003 - MAP Rationality Test Maximum (DTC P0106 Error)</title>
+    <description>For a given RPM and Throttle Percentage (% TPS), it is expected the MAP Sensor will not read more than this amount (kPa).&#013;&#010;&#013;&#010;If any of the individual values (kPa) are more than these values, then P0106 will be set.&#013;&#010;&#013;&#010;Column headings = Throttle Position (% TPS)&#013;&#010;Row headings = RPM</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="10" />
+      <LABEL index="2" value="20" />
+      <LABEL index="3" value="30" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="60" />
+      <LABEL index="7" value="70" />
+      <LABEL index="8" value="80" />
+      <LABEL index="9" value="90" />
+      <LABEL index="10" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>8</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1600" />
+      <LABEL index="3" value="2400" />
+      <LABEL index="4" value="3200" />
+      <LABEL index="5" value="4000" />
+      <LABEL index="6" value="4800" />
+      <LABEL index="7" value="5600" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x16B58" mmedelementsizebits="16" mmedrowcount="8" mmedcolcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>MAP (kPa)</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>105.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/204.8">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2FF6" flags="0x30">
+    <title>C3004 - MAP Rationality Test Minimum (DTC P0106 Error)</title>
+    <description>For a given RPM and Throttle Percentage (% TPS), it is expected the MAP Sensor will not read less than this amount (kPa).&#013;&#010;&#013;&#010;If any of the individual values (kPa) are less than these values, then P0106 will be set.&#013;&#010;&#013;&#010;Column headings = Throttle Position (% TPS)&#013;&#010;Row headings = RPM</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="10" />
+      <LABEL index="2" value="20" />
+      <LABEL index="3" value="30" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="60" />
+      <LABEL index="7" value="70" />
+      <LABEL index="8" value="80" />
+      <LABEL index="9" value="90" />
+      <LABEL index="10" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>8</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1600" />
+      <LABEL index="3" value="2400" />
+      <LABEL index="4" value="3200" />
+      <LABEL index="5" value="4000" />
+      <LABEL index="6" value="4800" />
+      <LABEL index="7" value="5600" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x16C08" mmedelementsizebits="16" mmedrowcount="8" mmedcolcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>MAP (kPa)</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>105.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/204.8">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x1680" flags="0xC">
+    <title>C3210 - Catalytic Converter Idle Test</title>
+    <description>The number of times the Idle Catalyst Test must run before reporting a Pass.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16A76" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units># of Tests to Pass</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x5CD9" flags="0xC">
+    <title>C3904 - TPS Test Minimum MAP (DTC P0121 Error)</title>
+    <description>This is the Lower MAP Threshold (kPa) to allow the TPS Diagnostic Tests to executed.  A failed TPS Diagnostic Test will set DTC P0121.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x1742E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MAP (kPa)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/204.8">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x5E8A" flags="0xC">
+    <title>C3905 - TPS Test Maximum MAP (DTC P0121 Error)</title>
+    <description>This is the Upper MAP Threshold (kPa) to allow the TPS Diagnostic Tests to executed.  A failed TPS Diagnostic Test will set DTC P0121.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x17430" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MAP (kPa)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>105.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/204.8">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x5932" flags="0x30">
+    <title>C3906 - TPS vs RPM Test Maximum Predicted % TPS</title>
+    <description>For this Diagnostic Test the PCM will monitor the actual TPS position (%) and Engine RPM, then referring to this table, it will expect the TPS (%) to be below, or equal to, these values (%) for a given RPM.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Max % TPS</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1200" />
+      <LABEL index="3" value="1600" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2400" />
+      <LABEL index="6" value="2800" />
+      <LABEL index="7" value="3200" />
+      <LABEL index="8" value="3600" />
+      <LABEL index="9" value="4000" />
+      <LABEL index="10" value="4400" />
+      <LABEL index="11" value="4800" />
+      <LABEL index="12" value="5200" />
+      <LABEL index="13" value="5600" />
+      <LABEL index="14" value="6000" />
+      <LABEL index="15" value="6400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x17444" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6D69" flags="0x30">
+    <title>C3907 - TPS vs RPM Test Minimum Predicted % TPS</title>
+    <description>For this Diagnostic Test the PCM will monitor the actual TPS position (%) and Engine RPM, then referring to this table, it will expect the TPS (%) to be above, or equal to, these values (%) for a given RPM.&#013;&#010;&#013;&#010;For vehicles equipped with a High Performance Camshaft, that Idle above stock RPMs, the Lower Thresholds (RPM) may need to be Lowered (%) to stop a TPS fault code being set.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Min % TPS</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>16</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="400" />
+      <LABEL index="1" value="800" />
+      <LABEL index="2" value="1200" />
+      <LABEL index="3" value="1600" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2400" />
+      <LABEL index="6" value="2800" />
+      <LABEL index="7" value="3200" />
+      <LABEL index="8" value="3600" />
+      <LABEL index="9" value="4000" />
+      <LABEL index="10" value="4400" />
+      <LABEL index="11" value="4800" />
+      <LABEL index="12" value="5200" />
+      <LABEL index="13" value="5600" />
+      <LABEL index="14" value="6000" />
+      <LABEL index="15" value="6400" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x17464" mmedelementsizebits="16" mmedrowcount="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>1</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x5E07" flags="0xC">
+    <title>C5501 - MAP Test Maximum RPM</title>
+    <description>If the Engine RPM is above this value, then the MAP Sensor Rationality Tests will not execute.  A failed MAP Sensor Rationality Test will cause DTC P0106 to be set.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16CEE" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xCB4" flags="0xC">
+    <title>C5502 - MAP Test Minimum RPM</title>
+    <description>If the Engine RPM is below this value, then the MAP Sensor Rationality Tests will not execute.  A failed MAP Sensor Rationality Test will cause DTC P0106 to be set.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x16CF0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7885" flags="0xC">
+    <title>C5601 - Misfire Detection Test Maximum Coolant Temp (F)</title>
+    <description>The maximum Engine Coolant Temperature (ECT) allowed before the Misfire Tests will be disabled.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1888C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x22B8" flags="0xC">
+    <title>C5602 - Misfire Detection Test Minimum Coolant Temp (F)</title>
+    <description>The minimum Engine Coolant Temperature (ECT) allowed before the Misfire Tests will be enabled.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1888E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x637" flags="0xC">
+    <title>C5605 - Misfire Detection Test Maximum RPM</title>
+    <description>The maximum RPM allowed before the Misfire Tests will be disabled.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x18892" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7303" flags="0xC">
+    <title>C5606 - Misfire Detection Test Minimum RPM</title>
+    <description>The minimum RPM allowed before the Misfire Tests will be enabled.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x18894" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>RPM</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>12799.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x2BA3" flags="0x30">
+    <title>C5621 - Misfire Test - Cylinder Mode Idle</title>
+    <description>The maximum Time Limit (microseconds) between Cylinder Events at Idle, that will be deemed a Misfire.  A value of 32766 (maximum value) in a cell, or immediately below or to the right of the cell, will disable Misfire Detection for that cell.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Engine Load (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="300" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="500" />
+      <LABEL index="3" value="600" />
+      <LABEL index="4" value="700" />
+      <LABEL index="5" value="800" />
+      <LABEL index="6" value="900" />
+      <LABEL index="7" value="1000" />
+      <LABEL index="8" value="1100" />
+      <LABEL index="9" value="1200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x17CE0" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Microseconds</units>
+      <decimalpl>0</decimalpl>
+      <min>-32767.000000</min>
+      <max>32766.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7E3C" flags="0x30">
+    <title>C5622 - Misfire Test - Cylinder Mode Low RPM</title>
+    <description>The maximum Time Limit (microseconds) between Cylinder Events at Low RPM, that will be deemed a Misfire.  A value of 32766 (maximum value) in a cell, or immediately below or to the right of the cell, will disable Misfire Detection for that cell.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Engine Load (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>10</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="300" />
+      <LABEL index="1" value="400" />
+      <LABEL index="2" value="500" />
+      <LABEL index="3" value="600" />
+      <LABEL index="4" value="700" />
+      <LABEL index="5" value="800" />
+      <LABEL index="6" value="900" />
+      <LABEL index="7" value="1000" />
+      <LABEL index="8" value="1100" />
+      <LABEL index="9" value="1200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x17E34" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="10" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Microseconds</units>
+      <decimalpl>0</decimalpl>
+      <min>-32767.000000</min>
+      <max>32766.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x22ED" flags="0x30">
+    <title>C5623 - Misfire Test - Cylinder Mode Mid RPM</title>
+    <description>The maximum Time Limit (microseconds) between Cylinder Events at Mid RPM, that will be deemed a Misfire.  A value of 32766 (maximum value) in a cell, or immediately below or to the right of the cell, will disable Misfire Detection for that cell.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Engine Load (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>28</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1200" />
+      <LABEL index="1" value="1400" />
+      <LABEL index="2" value="1600" />
+      <LABEL index="3" value="1800" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2200" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2600" />
+      <LABEL index="8" value="2800" />
+      <LABEL index="9" value="3000" />
+      <LABEL index="10" value="3200" />
+      <LABEL index="11" value="3400" />
+      <LABEL index="12" value="3600" />
+      <LABEL index="13" value="3800" />
+      <LABEL index="14" value="4000" />
+      <LABEL index="15" value="4200" />
+      <LABEL index="16" value="4400" />
+      <LABEL index="17" value="4600" />
+      <LABEL index="18" value="4800" />
+      <LABEL index="19" value="5000" />
+      <LABEL index="20" value="5200" />
+      <LABEL index="21" value="5400" />
+      <LABEL index="22" value="5600" />
+      <LABEL index="23" value="5800" />
+      <LABEL index="24" value="6000" />
+      <LABEL index="25" value="6200" />
+      <LABEL index="26" value="6400" />
+      <LABEL index="27" value="6600" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x17F88" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="28" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Microseconds</units>
+      <decimalpl>0</decimalpl>
+      <min>-32767.000000</min>
+      <max>32766.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7A79" flags="0x30">
+    <title>C5624 - Misfire Test - Cylinder Mode High RPM</title>
+    <description>The maximum Time Limit (microseconds) between Cylinder Events at High RPM, that will be deemed a Misfire.  A value of 32766 (maximum value) in a cell, or immediately below or to the right of the cell, will disable Misfire Detection for that cell.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Engine Load (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>2</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="6500" />
+      <LABEL index="1" value="7000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x18340" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Microseconds</units>
+      <decimalpl>0</decimalpl>
+      <min>-32767.000000</min>
+      <max>32766.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x75AD" flags="0x30">
+    <title>C5625 - Misfire Test - Revolution Mode Low RPM</title>
+    <description>The maximum Time Limit (microseconds) between full Engine Revolution Events at Low RPM, that will be deemed a Misfire.  A value of 32766 (maximum value) in a cell, or immediately below or to the right of the cell, will disable Misfire Detection for that cell.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Engine Load (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>3</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1000" />
+      <LABEL index="1" value="1100" />
+      <LABEL index="2" value="1200" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x18384" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Microseconds</units>
+      <decimalpl>0</decimalpl>
+      <min>-32767.000000</min>
+      <max>32766.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x105F" flags="0x30">
+    <title>C5626 - Misfire Test - Revolution Mode Mid RPM</title>
+    <description>The maximum Time Limit (microseconds) between full Engine Revolution Events at Mid RPM, that will be deemed a Misfire.  A value of 32766 (maximum value) in a cell, or immediately below or to the right of the cell, will disable Misfire Detection for that cell.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Engine Load (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>28</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1200" />
+      <LABEL index="1" value="1400" />
+      <LABEL index="2" value="1600" />
+      <LABEL index="3" value="1800" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2200" />
+      <LABEL index="6" value="2400" />
+      <LABEL index="7" value="2600" />
+      <LABEL index="8" value="2800" />
+      <LABEL index="9" value="3000" />
+      <LABEL index="10" value="3200" />
+      <LABEL index="11" value="3400" />
+      <LABEL index="12" value="3600" />
+      <LABEL index="13" value="3800" />
+      <LABEL index="14" value="4000" />
+      <LABEL index="15" value="4200" />
+      <LABEL index="16" value="4400" />
+      <LABEL index="17" value="4600" />
+      <LABEL index="18" value="4800" />
+      <LABEL index="19" value="5000" />
+      <LABEL index="20" value="5200" />
+      <LABEL index="21" value="5400" />
+      <LABEL index="22" value="5600" />
+      <LABEL index="23" value="5800" />
+      <LABEL index="24" value="6000" />
+      <LABEL index="25" value="6200" />
+      <LABEL index="26" value="6400" />
+      <LABEL index="27" value="6600" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x183EA" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="28" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Microseconds</units>
+      <decimalpl>0</decimalpl>
+      <min>-32767.000000</min>
+      <max>32766.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x813" flags="0x30">
+    <title>C5627 - Misfire Test - Revolution Mode High RPM</title>
+    <description>The maximum Time Limit (microseconds) between full Engine Revolution Events at High RPM, that will be deemed a Misfire.  A value of 32766 (maximum value) in a cell, or immediately below or to the right of the cell, will disable Misfire Detection for that cell.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = Engine Load (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>4</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="6500" />
+      <LABEL index="1" value="7000" />
+      <LABEL index="2" value="7500" />
+      <LABEL index="3" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x187A2" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="4" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>Microseconds</units>
+      <decimalpl>0</decimalpl>
+      <min>-32767.000000</min>
+      <max>32766.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x61A6" flags="0x30">
+    <title>C6001 - Diagnostic Trouble Code (DTC) Type</title>
+    <description>Used to Enable or Disable individual DTC processing.&#013;&#010;&#013;&#010;Settings:&#013;&#010;0 = 1 Trip, Emissions Related (MIL will illuminate IMMEDIATELY)&#013;&#010;&#013;&#010;1 = 2 Trips, Emissions Related (MIL will illuminate if the DTC is active for two consecutive drive cycles)&#013;&#010;&#013;&#010;2 = Non Emissions (MIL will NOT be illuminated, but the PCM will store the DTC)&#013;&#010;&#013;&#010;3 = Not Reported (the DTC test / algorithm is NOT functional, i.e. the DTC is Disabled)</description>
+    <CATEGORYMEM index="0" category="21" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Setting</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>DTC</units>
+      <indexcount>260</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="P0016" />
+      <LABEL index="1" value="P0068" />
+      <LABEL index="2" value="P0101" />
+      <LABEL index="3" value="P0102" />
+      <LABEL index="4" value="P0103" />
+      <LABEL index="5" value="P0106" />
+      <LABEL index="6" value="P0107" />
+      <LABEL index="7" value="P0108" />
+      <LABEL index="8" value="P0111" />
+      <LABEL index="9" value="P0112" />
+      <LABEL index="10" value="P0113" />
+      <LABEL index="11" value="P0116" />
+      <LABEL index="12" value="P0117" />
+      <LABEL index="13" value="P0118" />
+      <LABEL index="14" value="P0120" />
+      <LABEL index="15" value="P0121" />
+      <LABEL index="16" value="P0122" />
+      <LABEL index="17" value="P0123" />
+      <LABEL index="18" value="P0125" />
+      <LABEL index="19" value="P0128" />
+      <LABEL index="20" value="P0131" />
+      <LABEL index="21" value="P0132" />
+      <LABEL index="22" value="P0133" />
+      <LABEL index="23" value="P0134" />
+      <LABEL index="24" value="P0135" />
+      <LABEL index="25" value="P0136" />
+      <LABEL index="26" value="P0137" />
+      <LABEL index="27" value="P0138" />
+      <LABEL index="28" value="P0140" />
+      <LABEL index="29" value="P0141" />
+      <LABEL index="30" value="P0147" />
+      <LABEL index="31" value="P0151" />
+      <LABEL index="32" value="P0152" />
+      <LABEL index="33" value="P0153" />
+      <LABEL index="34" value="P0154" />
+      <LABEL index="35" value="P0155" />
+      <LABEL index="36" value="P0156" />
+      <LABEL index="37" value="P0157" />
+      <LABEL index="38" value="P0158" />
+      <LABEL index="39" value="P0160" />
+      <LABEL index="40" value="P0161" />
+      <LABEL index="41" value="P0167" />
+      <LABEL index="42" value="P0169" />
+      <LABEL index="43" value="P0170" />
+      <LABEL index="44" value="P0171" />
+      <LABEL index="45" value="P0172" />
+      <LABEL index="46" value="P0173" />
+      <LABEL index="47" value="P0174" />
+      <LABEL index="48" value="P0175" />
+      <LABEL index="49" value="P0177" />
+      <LABEL index="50" value="P0178" />
+      <LABEL index="51" value="P0179" />
+      <LABEL index="52" value="P0181" />
+      <LABEL index="53" value="P0182" />
+      <LABEL index="54" value="P0183" />
+      <LABEL index="55" value="P0200" />
+      <LABEL index="56" value="P0218" />
+      <LABEL index="57" value="P0220" />
+      <LABEL index="58" value="P0230" />
+      <LABEL index="59" value="P0234" />
+      <LABEL index="60" value="P0300" />
+      <LABEL index="61" value="P0315" />
+      <LABEL index="62" value="P0325" />
+      <LABEL index="63" value="P0327" />
+      <LABEL index="64" value="P0332" />
+      <LABEL index="65" value="P0335" />
+      <LABEL index="66" value="P0336" />
+      <LABEL index="67" value="P0341" />
+      <LABEL index="68" value="P0342" />
+      <LABEL index="69" value="P0343" />
+      <LABEL index="70" value="P0351" />
+      <LABEL index="71" value="P0352" />
+      <LABEL index="72" value="P0353" />
+      <LABEL index="73" value="P0354" />
+      <LABEL index="74" value="P0355" />
+      <LABEL index="75" value="P0356" />
+      <LABEL index="76" value="P0357" />
+      <LABEL index="77" value="P0358" />
+      <LABEL index="78" value="P0400" />
+      <LABEL index="79" value="P0401" />
+      <LABEL index="80" value="P0402" />
+      <LABEL index="81" value="P0404" />
+      <LABEL index="82" value="P0405" />
+      <LABEL index="83" value="P0409" />
+      <LABEL index="84" value="P0410" />
+      <LABEL index="85" value="P0412" />
+      <LABEL index="86" value="P0418" />
+      <LABEL index="87" value="P0420" />
+      <LABEL index="88" value="P0430" />
+      <LABEL index="89" value="P0442" />
+      <LABEL index="90" value="P0443" />
+      <LABEL index="91" value="P0446" />
+      <LABEL index="92" value="P0449" />
+      <LABEL index="93" value="P0452" />
+      <LABEL index="94" value="P0453" />
+      <LABEL index="95" value="P0455" />
+      <LABEL index="96" value="P0461" />
+      <LABEL index="97" value="P0462" />
+      <LABEL index="98" value="P0463" />
+      <LABEL index="99" value="P0480" />
+      <LABEL index="100" value="P0481" />
+      <LABEL index="101" value="P0483" />
+      <LABEL index="102" value="P0491" />
+      <LABEL index="103" value="P0492" />
+      <LABEL index="104" value="P0493" />
+      <LABEL index="105" value="P0495" />
+      <LABEL index="106" value="P0496" />
+      <LABEL index="107" value="P0500" />
+      <LABEL index="108" value="P0502" />
+      <LABEL index="109" value="P0503" />
+      <LABEL index="110" value="P0506" />
+      <LABEL index="111" value="P0507" />
+      <LABEL index="112" value="P0522" />
+      <LABEL index="113" value="P0523" />
+      <LABEL index="114" value="P0526" />
+      <LABEL index="115" value="P0530" />
+      <LABEL index="116" value="P0531" />
+      <LABEL index="117" value="P0560" />
+      <LABEL index="118" value="P0562" />
+      <LABEL index="119" value="P0563" />
+      <LABEL index="120" value="P0567" />
+      <LABEL index="121" value="P0568" />
+      <LABEL index="122" value="P0571" />
+      <LABEL index="123" value="P0601" />
+      <LABEL index="124" value="P0602" />
+      <LABEL index="125" value="P0604" />
+      <LABEL index="126" value="P0605" />
+      <LABEL index="127" value="P0606" />
+      <LABEL index="128" value="P0608" />
+      <LABEL index="129" value="P0609" />
+      <LABEL index="130" value="P0615" />
+      <LABEL index="131" value="P0622" />
+      <LABEL index="132" value="P0641" />
+      <LABEL index="133" value="P0645" />
+      <LABEL index="134" value="P0650" />
+      <LABEL index="135" value="P0651" />
+      <LABEL index="136" value="P0654" />
+      <LABEL index="137" value="P0700" />
+      <LABEL index="138" value="P0705" />
+      <LABEL index="139" value="P0706" />
+      <LABEL index="140" value="P0711" />
+      <LABEL index="141" value="P0712" />
+      <LABEL index="142" value="P0713" />
+      <LABEL index="143" value="P0716" />
+      <LABEL index="144" value="P0717" />
+      <LABEL index="145" value="P0719" />
+      <LABEL index="146" value="P0724" />
+      <LABEL index="147" value="P0730" />
+      <LABEL index="148" value="P0740" />
+      <LABEL index="149" value="P0741" />
+      <LABEL index="150" value="P0742" />
+      <LABEL index="151" value="P0748" />
+      <LABEL index="152" value="P0751" />
+      <LABEL index="153" value="P0752" />
+      <LABEL index="154" value="P0753" />
+      <LABEL index="155" value="P0756" />
+      <LABEL index="156" value="P0757" />
+      <LABEL index="157" value="P0758" />
+      <LABEL index="158" value="P0785" />
+      <LABEL index="159" value="P0801" />
+      <LABEL index="160" value="P0802" />
+      <LABEL index="161" value="P0803" />
+      <LABEL index="162" value="P0804" />
+      <LABEL index="163" value="P0833" />
+      <LABEL index="164" value="P0850" />
+      <LABEL index="165" value="P0856" />
+      <LABEL index="166" value="P0894" />
+      <LABEL index="167" value="P1106" />
+      <LABEL index="168" value="P1107" />
+      <LABEL index="169" value="P1111" />
+      <LABEL index="170" value="P1112" />
+      <LABEL index="171" value="P1114" />
+      <LABEL index="172" value="P1115" />
+      <LABEL index="173" value="P1121" />
+      <LABEL index="174" value="P1122" />
+      <LABEL index="175" value="P1125" />
+      <LABEL index="176" value="P1133" />
+      <LABEL index="177" value="P1134" />
+      <LABEL index="178" value="P1135" />
+      <LABEL index="179" value="P1136" />
+      <LABEL index="180" value="P1153" />
+      <LABEL index="181" value="P1154" />
+      <LABEL index="182" value="P1155" />
+      <LABEL index="183" value="P1156" />
+      <LABEL index="184" value="P1258" />
+      <LABEL index="185" value="P1274" />
+      <LABEL index="186" value="P1380" />
+      <LABEL index="187" value="P1381" />
+      <LABEL index="188" value="P1404" />
+      <LABEL index="189" value="P1410" />
+      <LABEL index="190" value="P1508" />
+      <LABEL index="191" value="P1509" />
+      <LABEL index="192" value="P1516" />
+      <LABEL index="193" value="P1527" />
+      <LABEL index="194" value="P1539" />
+      <LABEL index="195" value="P1546" />
+      <LABEL index="196" value="P1572" />
+      <LABEL index="197" value="P1574" />
+      <LABEL index="198" value="P1575" />
+      <LABEL index="199" value="P1585" />
+      <LABEL index="200" value="P1626" />
+      <LABEL index="201" value="P1630" />
+      <LABEL index="202" value="P1631" />
+      <LABEL index="203" value="P1637" />
+      <LABEL index="204" value="P1652" />
+      <LABEL index="205" value="P1654" />
+      <LABEL index="206" value="P1659" />
+      <LABEL index="207" value="P1660" />
+      <LABEL index="208" value="P1661" />
+      <LABEL index="209" value="P1663" />
+      <LABEL index="210" value="P1665" />
+      <LABEL index="211" value="P1666" />
+      <LABEL index="212" value="P1688" />
+      <LABEL index="213" value="P1689" />
+      <LABEL index="214" value="P1810" />
+      <LABEL index="215" value="P1811" />
+      <LABEL index="216" value="P1815" />
+      <LABEL index="217" value="P1819" />
+      <LABEL index="218" value="P1820" />
+      <LABEL index="219" value="P1822" />
+      <LABEL index="220" value="P1823" />
+      <LABEL index="221" value="P1825" />
+      <LABEL index="222" value="P1826" />
+      <LABEL index="223" value="P2025" />
+      <LABEL index="224" value="P2026" />
+      <LABEL index="225" value="P2027" />
+      <LABEL index="226" value="P2066" />
+      <LABEL index="227" value="P2067" />
+      <LABEL index="228" value="P2068" />
+      <LABEL index="229" value="P2101" />
+      <LABEL index="230" value="P2108" />
+      <LABEL index="231" value="P2119" />
+      <LABEL index="232" value="P2120" />
+      <LABEL index="233" value="P2121" />
+      <LABEL index="234" value="P2125" />
+      <LABEL index="235" value="P2126" />
+      <LABEL index="236" value="P2130" />
+      <LABEL index="237" value="P2131" />
+      <LABEL index="238" value="P2135" />
+      <LABEL index="239" value="P2279" />
+      <LABEL index="240" value="P2610" />
+      <LABEL index="241" value="P2636" />
+      <LABEL index="242" value="P2761" />
+      <LABEL index="243" value="P2771" />
+      <LABEL index="244" value="U0107" />
+      <LABEL index="245" value="U1000" />
+      <LABEL index="246" value="U1024" />
+      <LABEL index="247" value="U1026" />
+      <LABEL index="248" value="U1040" />
+      <LABEL index="249" value="U1041" />
+      <LABEL index="250" value="U1056" />
+      <LABEL index="251" value="U1057" />
+      <LABEL index="252" value="U1064" />
+      <LABEL index="253" value="U1096" />
+      <LABEL index="254" value="U1153" />
+      <LABEL index="255" value="U1192" />
+      <LABEL index="256" value="U1193" />
+      <LABEL index="257" value="U1255 " />
+      <LABEL index="258" value="U1300" />
+      <LABEL index="259" value="U1301" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x18A25" mmedelementsizebits="8" mmedrowcount="260" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>3.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6E08" flags="0x30">
+    <title>C6002 - Malfunction Indicator Lamp (MIL) Enable / Disable</title>
+    <description>Use to Enable or Disable the Malfunction Indicator Lamp (MIL) illumination for individual DTCs.&#013;&#010;&#013;&#010;0 = No MIL (i.e. lamp is always OFF for the individual DTC)&#013;&#010;&#013;&#010;1 = MIL (i.e. lamp may be commanded ON by the PCM, for the individual DTC)</description>
+    <CATEGORYMEM index="0" category="21" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MIL / No MIL</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>DTC</units>
+      <indexcount>260</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="P0016" />
+      <LABEL index="1" value="P0068" />
+      <LABEL index="2" value="P0101" />
+      <LABEL index="3" value="P0102" />
+      <LABEL index="4" value="P0103" />
+      <LABEL index="5" value="P0106" />
+      <LABEL index="6" value="P0107" />
+      <LABEL index="7" value="P0108" />
+      <LABEL index="8" value="P0111" />
+      <LABEL index="9" value="P0112" />
+      <LABEL index="10" value="P0113" />
+      <LABEL index="11" value="P0116" />
+      <LABEL index="12" value="P0117" />
+      <LABEL index="13" value="P0118" />
+      <LABEL index="14" value="P0120" />
+      <LABEL index="15" value="P0121" />
+      <LABEL index="16" value="P0122" />
+      <LABEL index="17" value="P0123" />
+      <LABEL index="18" value="P0125" />
+      <LABEL index="19" value="P0128" />
+      <LABEL index="20" value="P0131" />
+      <LABEL index="21" value="P0132" />
+      <LABEL index="22" value="P0133" />
+      <LABEL index="23" value="P0134" />
+      <LABEL index="24" value="P0135" />
+      <LABEL index="25" value="P0136" />
+      <LABEL index="26" value="P0137" />
+      <LABEL index="27" value="P0138" />
+      <LABEL index="28" value="P0140" />
+      <LABEL index="29" value="P0141" />
+      <LABEL index="30" value="P0147" />
+      <LABEL index="31" value="P0151" />
+      <LABEL index="32" value="P0152" />
+      <LABEL index="33" value="P0153" />
+      <LABEL index="34" value="P0154" />
+      <LABEL index="35" value="P0155" />
+      <LABEL index="36" value="P0156" />
+      <LABEL index="37" value="P0157" />
+      <LABEL index="38" value="P0158" />
+      <LABEL index="39" value="P0160" />
+      <LABEL index="40" value="P0161" />
+      <LABEL index="41" value="P0167" />
+      <LABEL index="42" value="P0169" />
+      <LABEL index="43" value="P0170" />
+      <LABEL index="44" value="P0171" />
+      <LABEL index="45" value="P0172" />
+      <LABEL index="46" value="P0173" />
+      <LABEL index="47" value="P0174" />
+      <LABEL index="48" value="P0175" />
+      <LABEL index="49" value="P0177" />
+      <LABEL index="50" value="P0178" />
+      <LABEL index="51" value="P0179" />
+      <LABEL index="52" value="P0181" />
+      <LABEL index="53" value="P0182" />
+      <LABEL index="54" value="P0183" />
+      <LABEL index="55" value="P0200" />
+      <LABEL index="56" value="P0218" />
+      <LABEL index="57" value="P0220" />
+      <LABEL index="58" value="P0230" />
+      <LABEL index="59" value="P0234" />
+      <LABEL index="60" value="P0300" />
+      <LABEL index="61" value="P0315" />
+      <LABEL index="62" value="P0325" />
+      <LABEL index="63" value="P0327" />
+      <LABEL index="64" value="P0332" />
+      <LABEL index="65" value="P0335" />
+      <LABEL index="66" value="P0336" />
+      <LABEL index="67" value="P0341" />
+      <LABEL index="68" value="P0342" />
+      <LABEL index="69" value="P0343" />
+      <LABEL index="70" value="P0351" />
+      <LABEL index="71" value="P0352" />
+      <LABEL index="72" value="P0353" />
+      <LABEL index="73" value="P0354" />
+      <LABEL index="74" value="P0355" />
+      <LABEL index="75" value="P0356" />
+      <LABEL index="76" value="P0357" />
+      <LABEL index="77" value="P0358" />
+      <LABEL index="78" value="P0400" />
+      <LABEL index="79" value="P0401" />
+      <LABEL index="80" value="P0402" />
+      <LABEL index="81" value="P0404" />
+      <LABEL index="82" value="P0405" />
+      <LABEL index="83" value="P0409" />
+      <LABEL index="84" value="P0410" />
+      <LABEL index="85" value="P0412" />
+      <LABEL index="86" value="P0418" />
+      <LABEL index="87" value="P0420" />
+      <LABEL index="88" value="P0430" />
+      <LABEL index="89" value="P0442" />
+      <LABEL index="90" value="P0443" />
+      <LABEL index="91" value="P0446" />
+      <LABEL index="92" value="P0449" />
+      <LABEL index="93" value="P0452" />
+      <LABEL index="94" value="P0453" />
+      <LABEL index="95" value="P0455" />
+      <LABEL index="96" value="P0461" />
+      <LABEL index="97" value="P0462" />
+      <LABEL index="98" value="P0463" />
+      <LABEL index="99" value="P0480" />
+      <LABEL index="100" value="P0481" />
+      <LABEL index="101" value="P0483" />
+      <LABEL index="102" value="P0491" />
+      <LABEL index="103" value="P0492" />
+      <LABEL index="104" value="P0493" />
+      <LABEL index="105" value="P0495" />
+      <LABEL index="106" value="P0496" />
+      <LABEL index="107" value="P0500" />
+      <LABEL index="108" value="P0502" />
+      <LABEL index="109" value="P0503" />
+      <LABEL index="110" value="P0506" />
+      <LABEL index="111" value="P0507" />
+      <LABEL index="112" value="P0522" />
+      <LABEL index="113" value="P0523" />
+      <LABEL index="114" value="P0526" />
+      <LABEL index="115" value="P0530" />
+      <LABEL index="116" value="P0531" />
+      <LABEL index="117" value="P0560" />
+      <LABEL index="118" value="P0562" />
+      <LABEL index="119" value="P0563" />
+      <LABEL index="120" value="P0567" />
+      <LABEL index="121" value="P0568" />
+      <LABEL index="122" value="P0571" />
+      <LABEL index="123" value="P0601" />
+      <LABEL index="124" value="P0602" />
+      <LABEL index="125" value="P0604" />
+      <LABEL index="126" value="P0605" />
+      <LABEL index="127" value="P0606" />
+      <LABEL index="128" value="P0608" />
+      <LABEL index="129" value="P0609" />
+      <LABEL index="130" value="P0615" />
+      <LABEL index="131" value="P0622" />
+      <LABEL index="132" value="P0641" />
+      <LABEL index="133" value="P0645" />
+      <LABEL index="134" value="P0650" />
+      <LABEL index="135" value="P0651" />
+      <LABEL index="136" value="P0654" />
+      <LABEL index="137" value="P0700" />
+      <LABEL index="138" value="P0705" />
+      <LABEL index="139" value="P0706" />
+      <LABEL index="140" value="P0711" />
+      <LABEL index="141" value="P0712" />
+      <LABEL index="142" value="P0713" />
+      <LABEL index="143" value="P0716" />
+      <LABEL index="144" value="P0717" />
+      <LABEL index="145" value="P0719" />
+      <LABEL index="146" value="P0724" />
+      <LABEL index="147" value="P0730" />
+      <LABEL index="148" value="P0740" />
+      <LABEL index="149" value="P0741" />
+      <LABEL index="150" value="P0742" />
+      <LABEL index="151" value="P0748" />
+      <LABEL index="152" value="P0751" />
+      <LABEL index="153" value="P0752" />
+      <LABEL index="154" value="P0753" />
+      <LABEL index="155" value="P0756" />
+      <LABEL index="156" value="P0757" />
+      <LABEL index="157" value="P0758" />
+      <LABEL index="158" value="P0785" />
+      <LABEL index="159" value="P0801" />
+      <LABEL index="160" value="P0802" />
+      <LABEL index="161" value="P0803" />
+      <LABEL index="162" value="P0804" />
+      <LABEL index="163" value="P0833" />
+      <LABEL index="164" value="P0850" />
+      <LABEL index="165" value="P0856" />
+      <LABEL index="166" value="P0894" />
+      <LABEL index="167" value="P1106" />
+      <LABEL index="168" value="P1107" />
+      <LABEL index="169" value="P1111" />
+      <LABEL index="170" value="P1112" />
+      <LABEL index="171" value="P1114" />
+      <LABEL index="172" value="P1115" />
+      <LABEL index="173" value="P1121" />
+      <LABEL index="174" value="P1122" />
+      <LABEL index="175" value="P1125" />
+      <LABEL index="176" value="P1133" />
+      <LABEL index="177" value="P1134" />
+      <LABEL index="178" value="P1135" />
+      <LABEL index="179" value="P1136" />
+      <LABEL index="180" value="P1153" />
+      <LABEL index="181" value="P1154" />
+      <LABEL index="182" value="P1155" />
+      <LABEL index="183" value="P1156" />
+      <LABEL index="184" value="P1258" />
+      <LABEL index="185" value="P1274" />
+      <LABEL index="186" value="P1380" />
+      <LABEL index="187" value="P1381" />
+      <LABEL index="188" value="P1404" />
+      <LABEL index="189" value="P1410" />
+      <LABEL index="190" value="P1508" />
+      <LABEL index="191" value="P1509" />
+      <LABEL index="192" value="P1516" />
+      <LABEL index="193" value="P1527" />
+      <LABEL index="194" value="P1539" />
+      <LABEL index="195" value="P1546" />
+      <LABEL index="196" value="P1572" />
+      <LABEL index="197" value="P1574" />
+      <LABEL index="198" value="P1575" />
+      <LABEL index="199" value="P1585" />
+      <LABEL index="200" value="P1626" />
+      <LABEL index="201" value="P1630" />
+      <LABEL index="202" value="P1631" />
+      <LABEL index="203" value="P1637" />
+      <LABEL index="204" value="P1652" />
+      <LABEL index="205" value="P1654" />
+      <LABEL index="206" value="P1659" />
+      <LABEL index="207" value="P1660" />
+      <LABEL index="208" value="P1661" />
+      <LABEL index="209" value="P1663" />
+      <LABEL index="210" value="P1665" />
+      <LABEL index="211" value="P1666" />
+      <LABEL index="212" value="P1688" />
+      <LABEL index="213" value="P1689" />
+      <LABEL index="214" value="P1810" />
+      <LABEL index="215" value="P1811" />
+      <LABEL index="216" value="P1815" />
+      <LABEL index="217" value="P1819" />
+      <LABEL index="218" value="P1820" />
+      <LABEL index="219" value="P1822" />
+      <LABEL index="220" value="P1823" />
+      <LABEL index="221" value="P1825" />
+      <LABEL index="222" value="P1826" />
+      <LABEL index="223" value="P2025" />
+      <LABEL index="224" value="P2026" />
+      <LABEL index="225" value="P2027" />
+      <LABEL index="226" value="P2066" />
+      <LABEL index="227" value="P2067" />
+      <LABEL index="228" value="P2068" />
+      <LABEL index="229" value="P2101" />
+      <LABEL index="230" value="P2108" />
+      <LABEL index="231" value="P2119" />
+      <LABEL index="232" value="P2120" />
+      <LABEL index="233" value="P2121" />
+      <LABEL index="234" value="P2125" />
+      <LABEL index="235" value="P2126" />
+      <LABEL index="236" value="P2130" />
+      <LABEL index="237" value="P2131" />
+      <LABEL index="238" value="P2135" />
+      <LABEL index="239" value="P2279" />
+      <LABEL index="240" value="P2610" />
+      <LABEL index="241" value="P2636" />
+      <LABEL index="242" value="P2761" />
+      <LABEL index="243" value="P2771" />
+      <LABEL index="244" value="U0107" />
+      <LABEL index="245" value="U1000" />
+      <LABEL index="246" value="U1024" />
+      <LABEL index="247" value="U1026" />
+      <LABEL index="248" value="U1040" />
+      <LABEL index="249" value="U1041" />
+      <LABEL index="250" value="U1056" />
+      <LABEL index="251" value="U1057" />
+      <LABEL index="252" value="U1064" />
+      <LABEL index="253" value="U1096" />
+      <LABEL index="254" value="U1153" />
+      <LABEL index="255" value="U1192" />
+      <LABEL index="256" value="U1193" />
+      <LABEL index="257" value="U1255 " />
+      <LABEL index="258" value="U1300" />
+      <LABEL index="259" value="U1301" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x18B2B" mmedelementsizebits="8" mmedrowcount="260" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6716" flags="0x30">
+    <title>C6101 - Electronic Throttle Control - Predicted Airflow</title>
+    <description>The calculated amount of Predicted Airflow at a specific RPM and Electronic Throttle Position.  If these values are exceeded DTC P1514 will set.&#013;&#010;&#013;&#010;Column headings = RPM&#013;&#010;Row headings = TPS (%)</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="500" />
+      <LABEL index="2" value="1000" />
+      <LABEL index="3" value="1500" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2500" />
+      <LABEL index="6" value="3000" />
+      <LABEL index="7" value="3500" />
+      <LABEL index="8" value="4000" />
+      <LABEL index="9" value="4500" />
+      <LABEL index="10" value="5000" />
+      <LABEL index="11" value="5500" />
+      <LABEL index="12" value="6000" />
+      <LABEL index="13" value="6500" />
+      <LABEL index="14" value="7000" />
+      <LABEL index="15" value="7500" />
+      <LABEL index="16" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="8" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% Load</units>
+      <indexcount>17</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <LABEL index="1" value="6.25" />
+      <LABEL index="2" value="12.50" />
+      <LABEL index="3" value="18.75" />
+      <LABEL index="4" value="25.00" />
+      <LABEL index="5" value="31.25" />
+      <LABEL index="6" value="37.50" />
+      <LABEL index="7" value="43.75" />
+      <LABEL index="8" value="50.00" />
+      <LABEL index="9" value="56.25" />
+      <LABEL index="10" value="62.50" />
+      <LABEL index="11" value="68.75" />
+      <LABEL index="12" value="75.00" />
+      <LABEL index="13" value="81.25" />
+      <LABEL index="14" value="87.50" />
+      <LABEL index="15" value="93.75" />
+      <LABEL index="16" value="100.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x192CA" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>mg per Cylinder</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>4096.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0625">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x262E" flags="0x30">
+    <title>C6102 - Electronic Throttle Control - Predicted MAF Airflow</title>
+    <description>The maximum Predicted MAF Airflow (mg per Cylinder) at a given RPM, for Electronic Throttle Control diagnostics.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Max MAF</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="500" />
+      <LABEL index="2" value="1000" />
+      <LABEL index="3" value="1500" />
+      <LABEL index="4" value="2000" />
+      <LABEL index="5" value="2500" />
+      <LABEL index="6" value="3000" />
+      <LABEL index="7" value="3500" />
+      <LABEL index="8" value="4000" />
+      <LABEL index="9" value="4500" />
+      <LABEL index="10" value="5000" />
+      <LABEL index="11" value="5500" />
+      <LABEL index="12" value="6000" />
+      <LABEL index="13" value="6500" />
+      <LABEL index="14" value="7000" />
+      <LABEL index="15" value="7500" />
+      <LABEL index="16" value="8000" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x19208" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>4096.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.0625">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x62C8" flags="0xC">
+    <title>C6301 - MAP Sensor Scaler</title>
+    <description>Used to scale the MAP Sensor Voltage output into a kPa value.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedaddress="0x195B8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>A/D Counts per kPa</units>
+    <rangehigh>1279.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.01953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x164F" flags="0xC">
+    <title>C6302 - MAP Sensor Offset</title>
+    <description>Offset value applied to the MAP Sensor value.</description>
+    <CATEGORYMEM index="0" category="20" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x195BA" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>kPa</units>
+    <rangehigh>104.000000</rangehigh>
+    <rangelow>-104.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.01953125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFFLAG uniqueid="0x5F58">
+    <title>D0301 - Transmission Abuse Protection Enable</title>
+    <description>If this is Disabled, the PCM will only execute Transmission Upshift and Downshift Torque Reduction. All other Transmission Torque Reduction Factors (i.e. Abuse Mode), will not be processed.&#013;&#010;&#013;&#010;Unchecked = Abuse Protection is Disabled&#013;&#010;&#013;&#010;Checked = Abuse Protection is Enabled</description>
+    <CATEGORYMEM index="0" category="14" />
+    <EMBEDDEDDATA mmedaddress="0x196BF" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFFLAG uniqueid="0x21BB">
+    <title>D0401 - CAGS / CARS (Enable / Disable)</title>
+    <description>Enable/ Disable the CARS/CAGS system from functioning.&#013;&#010;&#013;&#010;Applies only to Manual Transmission calibrations.&#013;&#010;&#013;&#010;Unchecked = Disabled&#013;&#010;&#013;&#010;Checked = Enabled</description>
+    <CATEGORYMEM index="0" category="14" />
+    <EMBEDDEDDATA mmedaddress="0x196A1" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x77F3" flags="0xC">
+    <title>D0409 - Shift Pattern Switch Type</title>
+    <description>These options enable the various Shift Pattern Modes within the PCM.  Note: C1 is the BLUE connector on the PCM.  Switch Types used must be Momentary connect to Ground.&#013;&#010;&#013;&#010;0 = No Switch - Performance Mode via a Switch is not functional.&#013;&#010;1 = One Switch - Performance Mode via a Switch can be activated (C1 pin71).&#013;&#010;2 = Two Switches - Performance Mode via a Switch can be activated (C1 pin71), and Manual Mode can be activated (C1 pin 31).&#013;&#010;3 = C2 Data Bus - Shift Pattern Modes are sent on the Data Bus to the PCM from another Module (eg. the BCM).</description>
+    <CATEGORYMEM index="0" category="14" />
+    <EMBEDDEDDATA mmedaddress="0x19667" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Switch Type</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>3.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x5EA4" flags="0x30">
+    <title>D0701 - Shift Pressure - Normal Mode (PSI)</title>
+    <description>This table configures the Torque Signal Pressure (PSI) for the Normal Mode Upshifts.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Engine Torque (Ft-lbs)&#013;&#010;&#013;&#010;The Pressure Control Solenoid (PCS), also referred to as the Force Motor, is controlled by the PCM by varying the electrical current flow to the Solenoid.  The PCM can vary the electrical current from 0.0 amps (High Pressure) to 1.1 amps (Low Pressure).  The Pressure Control Solenoid (PCS) produces a Torque Signal Pressure that determines the final transmission Line Pressure (PSI).&#013;&#010;&#013;&#010;Torque Signal Pressure range is from 0 PSI to 96 PSI&#013;&#010;Line Pressure range is from 55 PSI to 230 PSI</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Engine Torque</units>
+      <indexcount>33</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="15" />
+      <LABEL index="2" value="30" />
+      <LABEL index="3" value="44" />
+      <LABEL index="4" value="59" />
+      <LABEL index="5" value="74" />
+      <LABEL index="6" value="89" />
+      <LABEL index="7" value="103" />
+      <LABEL index="8" value="118" />
+      <LABEL index="9" value="133" />
+      <LABEL index="10" value="148" />
+      <LABEL index="11" value="162" />
+      <LABEL index="12" value="177" />
+      <LABEL index="13" value="192" />
+      <LABEL index="14" value="207" />
+      <LABEL index="15" value="221" />
+      <LABEL index="16" value="236" />
+      <LABEL index="17" value="251" />
+      <LABEL index="18" value="266" />
+      <LABEL index="19" value="280" />
+      <LABEL index="20" value="295" />
+      <LABEL index="21" value="310" />
+      <LABEL index="22" value="325" />
+      <LABEL index="23" value="340" />
+      <LABEL index="24" value="354" />
+      <LABEL index="25" value="369" />
+      <LABEL index="26" value="384" />
+      <LABEL index="27" value="399" />
+      <LABEL index="28" value="413" />
+      <LABEL index="29" value="428" />
+      <LABEL index="30" value="443" />
+      <LABEL index="31" value="458" />
+      <LABEL index="32" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x196CA" mmedelementsizebits="16" mmedrowcount="33" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>PSI</units>
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>96.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/64">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1D04" flags="0x30">
+    <title>D0702 - Shift Pressure - Performance Mode (PSI)</title>
+    <description>This table configures the Torque Signal Pressure (PSI) for the Normal Mode Upshifts.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Engine Torque (Ft-lbs)&#013;&#010;&#013;&#010;The Pressure Control Solenoid (PCS), also referred to as the Force Motor, is controlled by the PCM by varying the electrical current flow to the Solenoid.  The PCM can vary the electrical current from 0.0 amps (High Pressure) to 1.1 amps (Low Pressure).  The Pressure Control Solenoid (PCS) produces a Torque Signal Pressure that determines the final transmission Line Pressure (PSI).&#013;&#010;&#013;&#010;Torque Signal Pressure range is from 0 PSI to 96 PSI&#013;&#010;Line Pressure range is from 55 PSI to 230 PSI</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Engine Torque</units>
+      <indexcount>33</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="15" />
+      <LABEL index="2" value="30" />
+      <LABEL index="3" value="44" />
+      <LABEL index="4" value="59" />
+      <LABEL index="5" value="74" />
+      <LABEL index="6" value="89" />
+      <LABEL index="7" value="103" />
+      <LABEL index="8" value="118" />
+      <LABEL index="9" value="133" />
+      <LABEL index="10" value="148" />
+      <LABEL index="11" value="162" />
+      <LABEL index="12" value="177" />
+      <LABEL index="13" value="192" />
+      <LABEL index="14" value="207" />
+      <LABEL index="15" value="221" />
+      <LABEL index="16" value="236" />
+      <LABEL index="17" value="251" />
+      <LABEL index="18" value="266" />
+      <LABEL index="19" value="280" />
+      <LABEL index="20" value="295" />
+      <LABEL index="21" value="310" />
+      <LABEL index="22" value="325" />
+      <LABEL index="23" value="340" />
+      <LABEL index="24" value="354" />
+      <LABEL index="25" value="369" />
+      <LABEL index="26" value="384" />
+      <LABEL index="27" value="399" />
+      <LABEL index="28" value="413" />
+      <LABEL index="29" value="428" />
+      <LABEL index="30" value="443" />
+      <LABEL index="31" value="458" />
+      <LABEL index="32" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x19790" mmedelementsizebits="16" mmedrowcount="33" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>PSI</units>
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>96.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/64">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x2E0E" flags="0x30">
+    <title>D0801 - Upshift Torque Reduction - Normal Mode (%)</title>
+    <description>For the Normal Mode Upshifts, the PCM will attempt to reduce the Engine Torque (Ft-lbs) by this amount (%).&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Engine Torque (Ft-lbs)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Torque</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="30" />
+      <LABEL index="2" value="59" />
+      <LABEL index="3" value="89" />
+      <LABEL index="4" value="118" />
+      <LABEL index="5" value="148" />
+      <LABEL index="6" value="177" />
+      <LABEL index="7" value="207" />
+      <LABEL index="8" value="236" />
+      <LABEL index="9" value="266" />
+      <LABEL index="10" value="295" />
+      <LABEL index="11" value="325" />
+      <LABEL index="12" value="354" />
+      <LABEL index="13" value="384" />
+      <LABEL index="14" value="413" />
+      <LABEL index="15" value="443" />
+      <LABEL index="16" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A086" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/327.68">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5999" flags="0x30">
+    <title>D0802 - Upshift Torque Reduction - Performance Mode (%)</title>
+    <description>For the Performance Mode Upshifts, the PCM will attempt to reduce the Engine Torque (Ft-lbs) by this amount (%).&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Engine Torque (Ft-lbs)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Torque</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="30" />
+      <LABEL index="2" value="59" />
+      <LABEL index="3" value="89" />
+      <LABEL index="4" value="118" />
+      <LABEL index="5" value="148" />
+      <LABEL index="6" value="177" />
+      <LABEL index="7" value="207" />
+      <LABEL index="8" value="236" />
+      <LABEL index="9" value="266" />
+      <LABEL index="10" value="295" />
+      <LABEL index="11" value="325" />
+      <LABEL index="12" value="354" />
+      <LABEL index="13" value="384" />
+      <LABEL index="14" value="413" />
+      <LABEL index="15" value="443" />
+      <LABEL index="16" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A0EC" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/327.68">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6953" flags="0x30">
+    <title>D0804 - Downshift Torque Reduction (%)</title>
+    <description>For the Downshifts, the PCM will attempt to reduce the Engine Torque (Ft-lbs) by this amount (%).&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Engine Torque (Ft-lbs)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2&gt;1" />
+      <LABEL index="1" value="3&gt;2" />
+      <LABEL index="2" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Torque</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="30" />
+      <LABEL index="2" value="59" />
+      <LABEL index="3" value="89" />
+      <LABEL index="4" value="118" />
+      <LABEL index="5" value="148" />
+      <LABEL index="6" value="177" />
+      <LABEL index="7" value="207" />
+      <LABEL index="8" value="236" />
+      <LABEL index="9" value="266" />
+      <LABEL index="10" value="295" />
+      <LABEL index="11" value="325" />
+      <LABEL index="12" value="354" />
+      <LABEL index="13" value="384" />
+      <LABEL index="14" value="413" />
+      <LABEL index="15" value="443" />
+      <LABEL index="16" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A020" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/327.68">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0xBF5" flags="0x30">
+    <title>D0901 - Part Throttle Shift Speeds - Normal Mode (MPH)</title>
+    <description>This table configures the Normal Mode Part Throttle Shift Speeds (MPH), for both the Upshifts and the Downshifts.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;WOT Shift Speeds vs Mode (D0910)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>6</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <LABEL index="3" value="2&gt;1" />
+      <LABEL index="4" value="3&gt;2" />
+      <LABEL index="5" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A15E" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="6" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x62B8" flags="0x30">
+    <title>D0902 - Part Throttle Shift Speeds - Performance Mode (MPH)</title>
+    <description>This table configures the Performance Mode Part Throttle Shift Speeds (MPH), for both the Upshifts and the Downshifts.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;WOT Shift Speeds vs Mode (D0910)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>6</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <LABEL index="3" value="2&gt;1" />
+      <LABEL index="4" value="3&gt;2" />
+      <LABEL index="5" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A4DE" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="6" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7110" flags="0x30">
+    <title>D0903 - Part Throttle Shift Speeds - Hot Mode (MPH)</title>
+    <description>This table configures the Hot Mode Part Throttle Shift Speeds (MPH), for both the Upshifts and the Downshifts.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;WOT Shift Speeds vs Mode (D0910)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>6</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <LABEL index="3" value="2&gt;1" />
+      <LABEL index="4" value="3&gt;2" />
+      <LABEL index="5" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A412" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="6" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5DF3" flags="0x30">
+    <title>D0904 - Part Throttle Shift Speeds - Cruise Mode (MPH)</title>
+    <description>This table configures the Cruise Mode Part Throttle Shift Speeds (MPH), for both the Upshifts and the Downshifts.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;WOT Shift Speeds vs Mode (D0910)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>6</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <LABEL index="3" value="2&gt;1" />
+      <LABEL index="4" value="3&gt;2" />
+      <LABEL index="5" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A22A" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="6" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x1F96" flags="0x30">
+    <title>D0910 - WOT Shift Speeds vs Mode (MPH)</title>
+    <description>This table configures the Wide Open Throttle (WOT) Upshift and Downshift Speeds (MPH).&#013;&#010;&#013;&#010;Column headings = Shift Mode&#013;&#010;Row headings = Shift&#013;&#010;&#013;&#010;Normal = Normal Shift Mode&#013;&#010;Hot = Hot Shift Mode&#013;&#010;Perf. = Performance Shift Mode</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Mode</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Normal" />
+      <LABEL index="1" value="Hot" />
+      <LABEL index="2" value="Perf." />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>6</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <LABEL index="3" value="2&gt;1" />
+      <LABEL index="4" value="3&gt;2" />
+      <LABEL index="5" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A5AA" mmedelementsizebits="16" mmedrowcount="6" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5BF5" flags="0x30">
+    <title>D0913 - Manual Gear Selection Shift Speeds (MPH)</title>
+    <description>This table configures the Manually Selected Gear Shifts (i.e. caused by the driver moving the Gear Shift) - Upshift and Downshift Speeds (MPH).  The Upshift Speeds may be safely set to the maximum (254 MPH) - for full manual control of the Upshifts.  The Downshift Speeds must be CAREFULLY set, to avoid causing damage to the Engine or the Transmission.&#013;&#010;&#013;&#010;As an example, the 2&gt;1 Downshift:&#013;&#010;&#013;&#010;If this speed was set to the maximum (254 MPH), then if the driver manually selected 1st Gear using the Gear Shift, the Transmission would downshift at any speed - which could cause damage.&#013;&#010;&#013;&#010;This speed should be calculated to correspond to a REASONABLE RPM, in the Gear being downshifted into.  The 2&gt;1 Downshift may end up being in the 25 MPH to 40 MPH range.&#013;&#010;</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Speed" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>4</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;1" />
+      <LABEL index="2" value="2&gt;3" />
+      <LABEL index="3" value="3&gt;2" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A33E" mmedelementsizebits="16" mmedrowcount="4" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4C9C" flags="0x30">
+    <title>D0914 - 2nd Gear Manual Hold 1&gt;2 Shift Speeds (MPH)</title>
+    <description>The maximum Speed (MPH) before the PCM will force an Upshift into 2nd Gear, if the Gear Shift is being held in 2nd Gear.  This tables allows the vehicle to begin moving from a stopped position in 2nd Gear.  Typically used on slippery surfaces, like snow or ice.&#013;&#010;&#013;&#010;Setting to 0 MPH = starting off in 2nd Gear&#013;&#010;&#013;&#010;*** do not set the Speeds in this table too high - or the vehicle will NEVER shift out of 1st Gear, while being manually shifted by the driver ***</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="MPH" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A2F6" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4EFE" flags="0x30">
+    <title>D0940 - WOT Shift RPM - Normal Mode</title>
+    <description>The transmission will perform Normal Mode Upshifts at the indicated Engine Speed (RPM), if the PCM has entered WOT Shift Mode.&#013;&#010;&#013;&#010;Also see:&#013;&#010;WOT Shift Mode TPS Threshold (D1206)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="RPM" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A634" mmedelementsizebits="16" mmedrowcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>8191.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4124" flags="0x30">
+    <title>D0941 - WOT Shift RPM - Performance Mode</title>
+    <description>The transmission will perform Performance Mode Upshifts at the indicated Engine Speed (RPM), if the PCM has entered WOT Shift Mode.&#013;&#010;&#013;&#010;Also see:&#013;&#010;WOT Shift Mode TPS Threshold (D1206)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="RPM" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A646" mmedelementsizebits="16" mmedrowcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>8191.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x30D" flags="0x30">
+    <title>D0942 - WOT Shift RPM - Hot Mode</title>
+    <description>The transmission will perform Hot Mode Upshifts at the indicated Engine Speed (RPM), if the PCM has entered WOT Shift Mode.&#013;&#010;&#013;&#010;Also see:&#013;&#010;WOT Shift Mode TPS Threshold (D1206)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="RPM" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A63A" mmedelementsizebits="16" mmedrowcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>8191.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7AC8" flags="0x30">
+    <title>D0960 - Throttle Kickdown Speeds - Normal Mode (% TPS)</title>
+    <description>When in Normal Mode, the Transmission will execute a Kickdown (i.e. a Downshift), when Throttle Position (% TPS) exceeds the cell value (%).&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Vehicle Speed (MPH)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2&gt;1" />
+      <LABEL index="1" value="3&gt;2" />
+      <LABEL index="2" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="08" />
+      <LABEL index="2" value="16" />
+      <LABEL index="3" value="24" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="40" />
+      <LABEL index="6" value="48" />
+      <LABEL index="7" value="56" />
+      <LABEL index="8" value="64" />
+      <LABEL index="9" value="72" />
+      <LABEL index="10" value="80" />
+      <LABEL index="11" value="88" />
+      <LABEL index="12" value="96" />
+      <LABEL index="13" value="104" />
+      <LABEL index="14" value="112" />
+      <LABEL index="15" value="120" />
+      <LABEL index="16" value="128" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A66A" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/327.7">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3B9A" flags="0x30">
+    <title>D0961 - Throttle Kickdown Speeds - Cruise Mode (% TPS)</title>
+    <description>When in Cruise Mode, the Transmission will execute a Kickdown (i.e. a Downshift), when Throttle Position (% TPS) exceeds the cell value (%).&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Vehicle Speed (MPH)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2&gt;1" />
+      <LABEL index="1" value="3&gt;2" />
+      <LABEL index="2" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="08" />
+      <LABEL index="2" value="16" />
+      <LABEL index="3" value="24" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="40" />
+      <LABEL index="6" value="48" />
+      <LABEL index="7" value="56" />
+      <LABEL index="8" value="64" />
+      <LABEL index="9" value="72" />
+      <LABEL index="10" value="80" />
+      <LABEL index="11" value="88" />
+      <LABEL index="12" value="96" />
+      <LABEL index="13" value="104" />
+      <LABEL index="14" value="112" />
+      <LABEL index="15" value="120" />
+      <LABEL index="16" value="128" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A6D0" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/327.7">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x491A" flags="0x30">
+    <title>D0962 - Throttle Kickdown Speeds - Performance Mode (% TPS)</title>
+    <description>When in Performance Mode, the Transmission will execute a Kickdown (i.e. a Downshift), when Throttle Position (% TPS) exceeds the cell value (%).&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Vehicle Speed (MPH)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2&gt;1" />
+      <LABEL index="1" value="3&gt;2" />
+      <LABEL index="2" value="4&gt;3" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="08" />
+      <LABEL index="2" value="16" />
+      <LABEL index="3" value="24" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="40" />
+      <LABEL index="6" value="48" />
+      <LABEL index="7" value="56" />
+      <LABEL index="8" value="64" />
+      <LABEL index="9" value="72" />
+      <LABEL index="10" value="80" />
+      <LABEL index="11" value="88" />
+      <LABEL index="12" value="96" />
+      <LABEL index="13" value="104" />
+      <LABEL index="14" value="112" />
+      <LABEL index="15" value="120" />
+      <LABEL index="16" value="128" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A736" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/327.7">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x3483" flags="0x30">
+    <title>D1001 - TCC Apply Speeds - Normal Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be enabled.  At or above this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to lock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Release Speeds - Normal Mode (D1005)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A944" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4DCA" flags="0x30">
+    <title>D1002 - TCC Apply Speeds - Performance Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be enabled.  At or above this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to lock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Release Speeds - Performance Mode (D1006)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1ABA8" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5125" flags="0x30">
+    <title>D1003 - TCC Apply Speeds - Hot Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be enabled.  At or above this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to lock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Release Speeds - Hot Mode (D1007)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AADC" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7CFC" flags="0x30">
+    <title>D1004 - TCC Apply Speeds - Cruise Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be enabled.  At or above this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to lock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Release Speeds - Cruise Mode (D1008)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AA10" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x74B7" flags="0x30">
+    <title>D1005 - TCC Release Speeds - Normal Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be disabled.  At or below this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to unlock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Apply Speeds - Normal Mode (D1001)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1A9AA" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x57DF" flags="0x30">
+    <title>D1006 - TCC Release Speeds - Performance Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be disabled.  At or below this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to unlock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Apply Speeds - Performance Mode (D1002)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AC0E" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x44AD" flags="0x30">
+    <title>D1007 - TCC Release Speeds - Hot Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be disabled.  At or below this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to unlock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Apply Speeds - Hot Mode (D1003)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AB42" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6917" flags="0x30">
+    <title>D1008 - TCC Release Speeds - Cruise Mode (MPH)</title>
+    <description>This table configures the Vehicle Speed (MPH) when the Torque Converter Control (TCC) will be disabled.  At or below this Vehicle Speed (MPH), the Torque Converter (TC) will be commanded to unlock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Throttle Position (% TPS)&#013;&#010;&#013;&#010;Also see:&#013;&#010;TCC Apply Speeds - Cruise Mode (D1004)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="25" />
+      <LABEL index="5" value="31" />
+      <LABEL index="6" value="37" />
+      <LABEL index="7" value="43" />
+      <LABEL index="8" value="50" />
+      <LABEL index="9" value="56" />
+      <LABEL index="10" value="62" />
+      <LABEL index="11" value="68" />
+      <LABEL index="12" value="75" />
+      <LABEL index="13" value="81" />
+      <LABEL index="14" value="87" />
+      <LABEL index="15" value="93" />
+      <LABEL index="16" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AA76" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>254.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/256">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x6C56" flags="0x30">
+    <title>D1009 - TCC Release % TPS - Normal Mode</title>
+    <description>This table configures the Throttle Position (% TPS) when the Torque Converter Control (TCC) will be disabled.  At or above this Throttle Position (% TPS), the Torque Converter (TC) will be commanded to unlock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Speed (MPH)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="08" />
+      <LABEL index="2" value="16" />
+      <LABEL index="3" value="24" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="40" />
+      <LABEL index="6" value="48" />
+      <LABEL index="7" value="56" />
+      <LABEL index="8" value="64" />
+      <LABEL index="9" value="72" />
+      <LABEL index="10" value="80" />
+      <LABEL index="11" value="88" />
+      <LABEL index="12" value="96" />
+      <LABEL index="13" value="104" />
+      <LABEL index="14" value="112" />
+      <LABEL index="15" value="120" />
+      <LABEL index="16" value="128" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AEF0" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/328">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0xE91" flags="0x30">
+    <title>D1010 - TCC Release % TPS - Performance Mode</title>
+    <description>This table configures the Throttle Position (% TPS) when the Torque Converter Control (TCC) will be disabled.  At or above this Throttle Position (% TPS), the Torque Converter (TC) will be commanded to unlock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Speed (MPH)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="08" />
+      <LABEL index="2" value="16" />
+      <LABEL index="3" value="24" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="40" />
+      <LABEL index="6" value="48" />
+      <LABEL index="7" value="56" />
+      <LABEL index="8" value="64" />
+      <LABEL index="9" value="72" />
+      <LABEL index="10" value="80" />
+      <LABEL index="11" value="88" />
+      <LABEL index="12" value="96" />
+      <LABEL index="13" value="104" />
+      <LABEL index="14" value="112" />
+      <LABEL index="15" value="120" />
+      <LABEL index="16" value="128" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AFBC" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/328">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5807" flags="0x30">
+    <title>D1011 - TCC Release % TPS - Cruise Mode</title>
+    <description>This table configures the Throttle Position (% TPS) when the Torque Converter Control (TCC) will be disabled.  At or above this Throttle Position (% TPS), the Torque Converter (TC) will be commanded to unlock.&#013;&#010;&#013;&#010;Column headings = Gear&#013;&#010;Row headings = Speed (MPH)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="2nd" />
+      <LABEL index="1" value="3rd" />
+      <LABEL index="2" value="4th" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>MPH</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="08" />
+      <LABEL index="2" value="16" />
+      <LABEL index="3" value="24" />
+      <LABEL index="4" value="32" />
+      <LABEL index="5" value="40" />
+      <LABEL index="6" value="48" />
+      <LABEL index="7" value="56" />
+      <LABEL index="8" value="64" />
+      <LABEL index="9" value="72" />
+      <LABEL index="10" value="80" />
+      <LABEL index="11" value="88" />
+      <LABEL index="12" value="96" />
+      <LABEL index="13" value="104" />
+      <LABEL index="14" value="112" />
+      <LABEL index="15" value="120" />
+      <LABEL index="16" value="128" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1AF56" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/328">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x4A51" flags="0x30">
+    <title>D1101 - Shift Pressure - PCM Adapt Adjust (PSI)</title>
+    <description>This table configures the amount that the Transmission Adapt Values may modify the Line Pressures (PSI).&#013;&#010;&#013;&#010;Row headings = Engine Torque (Ft-lbs)&#013;&#010;&#013;&#010;Column headings:&#013;&#010;L 1&gt;2 = the amount the Pressure (PSI) may be Decreased for the 1&gt;2 Upshift&#013;&#010;L 2&gt;3 = the amount the Pressure (PSI) may be Decreased for the 2&gt;3 Upshift&#013;&#010;L 3&gt;4 = the amount the Pressure (PSI) may be Decreased for the 3&gt;4 Upshift&#013;&#010;HIGH = the amount the Pressure (PSI) may be Increased for ALL Upshifts</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>4</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="L  1&gt;2" />
+      <LABEL index="1" value="L  2&gt;3" />
+      <LABEL index="2" value="L  3&gt;4" />
+      <LABEL index="3" value="HIGH" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Torque</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="30" />
+      <LABEL index="2" value="59" />
+      <LABEL index="3" value="89" />
+      <LABEL index="4" value="118" />
+      <LABEL index="5" value="148" />
+      <LABEL index="6" value="177" />
+      <LABEL index="7" value="207" />
+      <LABEL index="8" value="236" />
+      <LABEL index="9" value="266" />
+      <LABEL index="10" value="295" />
+      <LABEL index="11" value="325" />
+      <LABEL index="12" value="354" />
+      <LABEL index="13" value="384" />
+      <LABEL index="14" value="413" />
+      <LABEL index="15" value="443" />
+      <LABEL index="16" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x05" mmedaddress="0x1B0EE" mmedelementsizebits="8" mmedrowcount="17" mmedcolcount="4" mmedmajorstridebits="0" mmedminorstridebits="16" />
+      <units>PSI</units>
+      <decimalpl>0</decimalpl>
+      <min>-29.000000</min>
+      <max>29.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/4">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5D21" flags="0x30">
+    <title>D1108 - Shift Times - Normal Mode (Seconds)</title>
+    <description>This table configures the Normal Mode Upshift times (seconds) for the Transmission Adapt Values.  Setting any value to 0.00 will disable Adaptive Shift Learning.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Engine Torque (Ft-lbs)&#013;&#010;&#013;&#010;There are three (3) Modes of Transmission Operation:&#013;&#010;1. Normal - the Normal Operating Mode of the transmission.&#013;&#010;2. Performance - some vehicles have the option to switch to a Performance Mode shift pattern.&#013;&#010;3. Cruise - if Cruise Control is active.</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Torque</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="30" />
+      <LABEL index="2" value="59" />
+      <LABEL index="3" value="89" />
+      <LABEL index="4" value="118" />
+      <LABEL index="5" value="148" />
+      <LABEL index="6" value="177" />
+      <LABEL index="7" value="207" />
+      <LABEL index="8" value="236" />
+      <LABEL index="9" value="266" />
+      <LABEL index="10" value="295" />
+      <LABEL index="11" value="325" />
+      <LABEL index="12" value="354" />
+      <LABEL index="13" value="384" />
+      <LABEL index="14" value="413" />
+      <LABEL index="15" value="443" />
+      <LABEL index="16" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1B022" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>4.900000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0xEBE" flags="0x30">
+    <title>D1109 - Shift Times - Performance Mode (Seconds)</title>
+    <description>This table configures the Performance Mode Upshift times (seconds) for the Transmission Adapt Values.  Setting any value to 0.00 will disable Adaptive Shift Learning.&#013;&#010;&#013;&#010;Column headings = Shift&#013;&#010;Row headings = Engine Torque (Ft-lbs)&#013;&#010;&#013;&#010;There are three (3) Modes of Transmission Operation:&#013;&#010;1. Normal - the Normal Operating Mode of the transmission.&#013;&#010;2. Performance - some vehicles have the option to switch to a Performance Mode shift pattern.&#013;&#010;3. Cruise - if Cruise Control is active.</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Shift</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1&gt;2" />
+      <LABEL index="1" value="2&gt;3" />
+      <LABEL index="2" value="3&gt;4" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Torque</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="30" />
+      <LABEL index="2" value="59" />
+      <LABEL index="3" value="89" />
+      <LABEL index="4" value="118" />
+      <LABEL index="5" value="148" />
+      <LABEL index="6" value="177" />
+      <LABEL index="7" value="207" />
+      <LABEL index="8" value="236" />
+      <LABEL index="9" value="266" />
+      <LABEL index="10" value="295" />
+      <LABEL index="11" value="325" />
+      <LABEL index="12" value="354" />
+      <LABEL index="13" value="384" />
+      <LABEL index="14" value="413" />
+      <LABEL index="15" value="443" />
+      <LABEL index="16" value="472" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1B088" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="3" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>4.900000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/160">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x154D" flags="0x30">
+    <title>D1201 - Transmission Gear Ratios</title>
+    <description>Transmission Gear Ratios.&#013;&#010;&#013;&#010;*** applicable to 4L60E or 4L80E transmissions only ***</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Ratio</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Gear</units>
+      <indexcount>5</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="1st" />
+      <LABEL index="1" value="2nd" />
+      <LABEL index="2" value="3rd" />
+      <LABEL index="3" value="4th" />
+      <LABEL index="4" value="Reverse" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedrowcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>3</decimalpl>
+      <min>0.000000</min>
+      <max>8.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="1" equation="X/4096">
+        <VAR id="X" type="address" address="0x1B23C" sizeinbits="16" />
+      </MATH>
+      <MATH row="2" col="1" equation="X/4096">
+        <VAR id="X" type="address" address="0x1B23E" sizeinbits="16" />
+      </MATH>
+      <MATH row="3" col="1" equation="X/4096">
+        <VAR id="X" type="address" address="0x1B2FC" sizeinbits="16" />
+      </MATH>
+      <MATH row="4" col="1" equation="X/4096">
+        <VAR id="X" type="address" address="0x1B2FE" sizeinbits="16" />
+      </MATH>
+      <MATH row="5" col="1" equation="X/4096">
+        <VAR id="X" type="address" address="0x1B240" sizeinbits="16" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7C62" flags="0x30">
+    <title>D1206 - WOT Shift Mode TPS Threshold (% TPS)</title>
+    <description>This table configures the Throttle Position (% TPS), that will Enable or Disable the use of the Wide Open Throttle (WOT) shift tables.&#013;&#010;&#013;&#010;There are three (3) WOT Shift Modes: Normal, Four Wheel Drive Low (4wdLo), and Cruise.&#013;&#010;&#013;&#010;Enabled = when the Throttle Position (% TPS) moves above this value, the PCM uses the WOT Shift Tables.&#013;&#010;&#013;&#010;Disabled = when the Throttle Position (% TPS) falls below this value, the PCM uses the Part Throttle Shift Tables.</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>% TPS</units>
+      <indexcount>2</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Disable" />
+      <LABEL index="1" value="Enable" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Mode</units>
+      <indexcount>3</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Normal" />
+      <LABEL index="1" value="4wdLo" />
+      <LABEL index="2" value="Cruise" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedaddress="0x1B24E" mmedelementsizebits="16" mmedrowcount="3" mmedcolcount="2" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>99.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/328">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFFLAG uniqueid="0x14B0">
+    <title>D2801 - TCC Lock During Shift</title>
+    <description>Unchecked = Disabled&#013;&#010;&#013;&#010;Checked = Enabled</description>
+    <CATEGORYMEM index="0" category="14" />
+    <EMBEDDEDDATA mmedaddress="0x1C7A0" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x61DF" flags="0xC">
+    <title>D2901 - TCC Minimum Pressure (PSI)</title>
+    <description>The minimum Torque Converter Control (TCC) Pressure (PSI) that may be commanded.</description>
+    <CATEGORYMEM index="0" category="14" />
+    <EMBEDDEDDATA mmedaddress="0x1C876" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>PSI</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x40F7" flags="0xC">
+    <title>D2902 - TCC Maximum Pressure (PSI)</title>
+    <description>The maximum Torque Converter Control (TCC) Pressure (PSI) that may be commanded.</description>
+    <CATEGORYMEM index="0" category="14" />
+    <EMBEDDEDDATA mmedaddress="0x1C8A0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>PSI</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x4AFF" flags="0x30">
+    <title>D2903 - TCC Solenoid Minimum PWM (%)</title>
+    <description>The minimum Pulse Width Modulated (PWM) TCC Duty Cycle (%) that may be commanded.&#013;&#010;&#013;&#010;Column headings = (TFT) Transmission Fluid Temperature (F)&#013;&#010;Row headings = Torque Converter Pressure (PSI)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (TFT)</units>
+      <indexcount>5</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F  32" />
+      <LABEL index="1" value="91" />
+      <LABEL index="2" value="151" />
+      <LABEL index="3" value="210" />
+      <LABEL index="4" value="270" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>PSI</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="24" />
+      <LABEL index="5" value="30" />
+      <LABEL index="6" value="36" />
+      <LABEL index="7" value="42" />
+      <LABEL index="8" value="48" />
+      <LABEL index="9" value="54" />
+      <LABEL index="10" value="60" />
+      <LABEL index="11" value="66" />
+      <LABEL index="12" value="72" />
+      <LABEL index="13" value="78" />
+      <LABEL index="14" value="84" />
+      <LABEL index="15" value="90" />
+      <LABEL index="16" value="96" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1C96E" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% PWM</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/328">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x5759" flags="0x30">
+    <title>D2904 - TCC Solenoid Maximum PWM (%)</title>
+    <description>The maximum Pulse Width Modulated (PWM) TCC Duty Cycle (%) that may be commanded.&#013;&#010;&#013;&#010;Column headings = (TFT) Transmission Fluid Temperature (F)&#013;&#010;Row headings = Torque Converter Pressure (PSI)</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Deg F (TFT)</units>
+      <indexcount>5</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F  32" />
+      <LABEL index="1" value="91" />
+      <LABEL index="2" value="151" />
+      <LABEL index="3" value="210" />
+      <LABEL index="4" value="270" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>PSI</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="06" />
+      <LABEL index="2" value="12" />
+      <LABEL index="3" value="18" />
+      <LABEL index="4" value="24" />
+      <LABEL index="5" value="30" />
+      <LABEL index="6" value="36" />
+      <LABEL index="7" value="42" />
+      <LABEL index="8" value="48" />
+      <LABEL index="9" value="54" />
+      <LABEL index="10" value="60" />
+      <LABEL index="11" value="66" />
+      <LABEL index="12" value="72" />
+      <LABEL index="13" value="78" />
+      <LABEL index="14" value="84" />
+      <LABEL index="15" value="90" />
+      <LABEL index="16" value="96" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1C8A2" mmedelementsizebits="16" mmedrowcount="17" mmedcolcount="5" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>% PWM</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>100.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/328">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x7C9E" flags="0x30">
+    <title>D2905 - TCC Pressure Apply Rate (PSI)</title>
+    <description>The rate at which the TCC Apply Pressure (PSI) is increased.</description>
+    <CATEGORYMEM index="0" category="14" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>PSI / Second</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>RPM SLIP</units>
+      <indexcount>17</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="-80" />
+      <LABEL index="1" value="-60" />
+      <LABEL index="2" value="-40" />
+      <LABEL index="3" value="-20" />
+      <LABEL index="4" value="00" />
+      <LABEL index="5" value="20" />
+      <LABEL index="6" value="40" />
+      <LABEL index="7" value="60" />
+      <LABEL index="8" value="80" />
+      <LABEL index="9" value="100" />
+      <LABEL index="10" value="120" />
+      <LABEL index="11" value="140" />
+      <LABEL index="12" value="160" />
+      <LABEL index="13" value="180" />
+      <LABEL index="14" value="200" />
+      <LABEL index="15" value="220" />
+      <LABEL index="16" value="240" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1CA18" mmedelementsizebits="16" mmedrowcount="17" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <units>PSI</units>
+      <decimalpl>1</decimalpl>
+      <min>0.000000</min>
+      <max>399.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X/51.2">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFTABLE uniqueid="0x41E5" flags="0x30">
+    <title>F0501 - Fuel Gauge Calibration</title>
+    <description>This table determines the Pulse Width Modulation (PWM) for a Fuel Gauge that is driven directly from the PCM.  If this table is zeroed in your stock tune, then assume the PCM does not control the Fuel Gauge via Pulse Width Modulation - it may be done via Serial Data.</description>
+    <CATEGORYMEM index="0" category="15" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>PWM %</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Tank %</units>
+      <indexcount>11</indexcount>
+      <outputtype>2</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="00" />
+      <LABEL index="1" value="10" />
+      <LABEL index="2" value="20" />
+      <LABEL index="3" value="30" />
+      <LABEL index="4" value="40" />
+      <LABEL index="5" value="50" />
+      <LABEL index="6" value="60" />
+      <LABEL index="7" value="70" />
+      <LABEL index="8" value="80" />
+      <LABEL index="9" value="90" />
+      <LABEL index="10" value="100" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1E1E6" mmedelementsizebits="16" mmedrowcount="11" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>2</decimalpl>
+      <min>-200.000000</min>
+      <max>200.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X*0.01953125">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFFLAG uniqueid="0x63C8">
+    <title>G0106 - A/C Auto Recirculation</title>
+    <description>The PCM has a few dual purpose outputs.  The A/C Auto Recirculation output is also used for Radiator Cooling Fan #2 control.  This option changes the output for either A/C Auto Recirculation Control or for Radiator Cooling Fan #2 control.&#013;&#010;&#013;&#010;Unchecked = Fan #2 Control&#013;&#010;&#013;&#010;Checked = Auto Recirculation&#013;&#010;&#013;&#010;Also see:&#013;&#010;Type of Radiator Cooling Fans (G1203)</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1F81C" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFFLAG uniqueid="0x24FA">
+    <title>G0801 - Column Lock Option</title>
+    <description>Enables or Disables the Column Lock Anti-theft System (if so equipped).&#013;&#010;&#013;&#010;Unchecked = Disabled&#013;&#010;&#013;&#010;Checked = Enabled</description>
+    <CATEGORYMEM index="0" category="1" />
+    <EMBEDDEDDATA mmedaddress="0x1FA50" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <mask>0x01</mask>
+  </XDFFLAG>
+  <XDFCONSTANT uniqueid="0x5FDF" flags="0xC">
+    <title>G0901 - Fan #1 Turn-on Temp</title>
+    <description>Radiator Cooling Fan #1 will turn on if the Engine Coolant Temperature (ECT) is above this value.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1FA58" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x69F6" flags="0xC">
+    <title>G0902 - Fan #1 Turn-off Temp</title>
+    <description>Radiator Cooling Fan #1 will turn off if the Engine Coolant Temperature (ECT) is below this value.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1FA5A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3006" flags="0xC">
+    <title>G0903 - Fan #1 Turn-on Temp (A/C On)</title>
+    <description>Radiator Cooling Fan #1 will turn on if the Engine Coolant Temperature (ECT) is above this value and the A/C is on.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1FA5C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x560F" flags="0xC">
+    <title>G0904 - Fan #1 Turn-off Speed</title>
+    <description>Radiator Cooling Fan #1 will turn off if the vehicle Speed (MPH) is above this value.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA66" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x43E" flags="0xC">
+    <title>G0905 - Fan #1 Turn-on Speed</title>
+    <description>Radiator Cooling Fan #1 will turn back on (if needed) when the vehicle Speed (MPH) is below this value.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA68" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1D57" flags="0xC">
+    <title>G0906 - Fan #1 Turn-on Delay</title>
+    <description>If conditions are met to turn on Radiator Cooling Fan #1, there will be a delay for this long (seconds), before actually switching on the Fan.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA7E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x72AE" flags="0xC">
+    <title>G0907 - Fan #1 Turn-off Delay</title>
+    <description>Once the PCM has decided that Radiator Cooling Fan #1 is to be switched off, it won&apos;t actually be turned off until this amount of time (seconds) has elapsed.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA80" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6357" flags="0xC">
+    <title>G0908 - Fan #1 Minimum On-Time</title>
+    <description>Once Radiator Cooling Fan #1 has been turned on, this is the minimum time (seconds) it will remain on before being turned off.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA6C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3A12" flags="0xC">
+    <title>G0909 - Fan #1 Run-on Temp</title>
+    <description>If the Engine Coolant Temperature (ECT) at shutdown is above this, then Radiator Cooling Fan #1 will remain on, even with ignition off.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Fan #1 Run-on Time (G0910)</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1FA5E" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6415" flags="0xC">
+    <title>G0910 - Fan #1 Run-on Time</title>
+    <description>If Radiator Cooling Fan #1 is in Run-on Mode, it will remain on for this long (seconds) after ignition has been turned off.&#013;&#010;&#013;&#010;Also see:&#013;&#010;Fan #1 Run-on Temp (G0909)</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA86" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x552E" flags="0xC">
+    <title>G0911 - Fan #1 A/C Pressure Enable</title>
+    <description>If the A/C Pressure is above this value (PSI), then the PCM will turn on Radiator Cooling Fan #1.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA54" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>PSI</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>499.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3980" flags="0xC">
+    <title>G0912 - Fan #1 A/C Pressure Disable</title>
+    <description>If the A/C Pressure (PSI) is below this value then Radiator Cooling Fan #1 can be turned off.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA56" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>PSI</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>499.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1CDB" flags="0xC">
+    <title>G0913 - Fan #2 Turn-on Temp</title>
+    <description>Radiator Cooling Fan #2 will turn on if the Engine Coolant Temperature (ECT) reaches, or is above, this value.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1FA78" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x632" flags="0xC">
+    <title>G0914 - Fan #2 Turn-off Temp</title>
+    <description>Radiator Cooling Fan #2 will turn off if the Engine Coolant Temperature (ECT) falls below this value.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedtypeflags="0x01" mmedaddress="0x1FA7A" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Deg F (ECT)</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>283.000000</rangehigh>
+    <rangelow>-39.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="(X*0.0703125)+32">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xFF6" flags="0xC">
+    <title>G0915 - Fan #2 Turn-on Delay</title>
+    <description>If conditions are met to turn on Radiator Cooling Fan #2, there will be a delay for this long (seconds) before actually switching on the Fan.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA82" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1B21" flags="0xC">
+    <title>G0916 - Fan #2 Turn-off Delay</title>
+    <description>Once the PCM has decided that Radiator Cooling Fan #2 is to be turned off, it won&apos;t actually be turned off until this amount of time (seconds) has elapsed.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA84" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xD6D" flags="0xC">
+    <title>G0917 - Fan #2 Minimum On-Time</title>
+    <description>Once Radiator Cooling Fan #2 has been turned on, this is the minimum time (seconds) it will remain on before being turned off.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA7C" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4D5F" flags="0xC">
+    <title>G0918 - Fan #2 A/C Pressure Enable</title>
+    <description>If the A/C Pressure (PSI) is above this value, then the PCM will turn on Radiator Cooling Fan #2.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA74" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>PSI</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>499.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x922" flags="0xC">
+    <title>G0919 - Fan #2 A/C Pressure Disable</title>
+    <description>If the A/C Pressure (PSI) is below this value then Radiator Cooling Fan #2 can be turned off.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA76" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>PSI</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>499.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/5.12">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x73DD" flags="0xC">
+    <title>G0920 - Fan #1 and #2 Both Off (MPH)</title>
+    <description>Above this vehicle Speed (MPH), both Radiator Cooling Fans will be switched off, unless above Engine Coolant Temperature (ECT) turn on thresholds.</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1FA64" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/128">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2871" flags="0xC">
+    <title>G1201 - VATS (Vehicle Anti Theft System)</title>
+    <description>Configures the Vehicle Anti Theft System (VATS).  If the system is active, and if the proper parameters are NOT met to allow the vehicle to start, Fuel will be cut off.&#013;&#010;&#013;&#010;0 = VATS Active (via Class 2 (or Serial Data) communications)&#013;&#010;1 = VATS Active (via Pulse Width Modulated (PWM) signal)&#013;&#010;2 = VATS Inactive (i.e. VATS Disabled)</description>
+    <CATEGORYMEM index="0" category="1" />
+    <EMBEDDEDDATA mmedaddress="0x1F784" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <decimalpl>0</decimalpl>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x2E58" flags="0xC">
+    <title>G1203 - Type of Radiator Cooling Fans</title>
+    <description>Used to configure the Type of Radiator Cooling Fans fitted to the vehicle.&#013;&#010;&#013;&#010;0 = Series Parallel Fans - both Fan Outputs (1 &amp; 2) are used to control two Fans.&#013;&#010;&#013;&#010;1 = Auxiliary Fan - only the Fan1 Output is used, to control one Fan.&#013;&#010;&#013;&#010;2 = No Fans.&#013;&#010;&#013;&#010;Also see:&#013;&#010;A/C Auto Recirculation (G0106)</description>
+    <CATEGORYMEM index="0" category="16" />
+    <EMBEDDEDDATA mmedaddress="0x1F77E" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Fan Type</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>2.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x68B8" flags="0xC">
+    <title>G1204 - Tach High Pulses</title>
+    <description>The number of Crankshaft Pulses (24x pulses) to hold the Tach Output High.  This value should match Tach Low Pulses (B1205).&#013;&#010;&#013;&#010;eg.:&#013;&#010;If G1204 and G1205 are both set to 6 = typical 4 cylinder Tach Output&#013;&#010;If G1204 and G1205 are both set to 3 = typical 8 cylinder Tach Output</description>
+    <CATEGORYMEM index="0" category="18" />
+    <EMBEDDEDDATA mmedaddress="0x1F780" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <decimalpl>0</decimalpl>
+    <rangehigh>16.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3FD7" flags="0xC">
+    <title>G1205 - Tach Low Pulses</title>
+    <description>The number of Crankshaft Pulses (24x pulses) to hold the Tach Output Low.  This value should match Tach High Pulses (B1204).&#013;&#010;&#013;&#010;eg.:&#013;&#010;If G1204 and G1205 are both set to 6 = typical 4 cylinder Tach Output&#013;&#010;If G1204 and G1205 are both set to 3 = typical 8 cylinder Tach Output</description>
+    <CATEGORYMEM index="0" category="18" />
+    <EMBEDDEDDATA mmedaddress="0x1F782" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <decimalpl>0</decimalpl>
+    <rangehigh>16.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x4CC5" flags="0xC">
+    <title>G1206 - Vehicle Platform</title>
+    <description>This parameter defines the Vehicle Platform programmed in this calibration.&#013;&#010;&#013;&#010;*** This parameter should NOT be changed ***&#013;&#010;&#013;&#010;Also see:&#013;&#010;Vehicle Platform Options (G1207)&#013;&#010;&#013;&#010;0 = F-body (ex. Camaro/Firebird)&#013;&#010;1 = Y-body (ex. Corvette)&#013;&#010;2 = Holden&#013;&#010;3 = GMT 530 (ex. GMC Kodiac/Topkick)&#013;&#010;4 = GMT 540 (ex. Isuzu box truck)&#013;&#010;5 = GMT 560 (ex. GMC Kodiac/Topkick)&#013;&#010;6 = GMT 610 (ex. GMC Express van)&#013;&#010;7 = GMT 800 (ex. Chevrolet Silverado)&#013;&#010;8 = ML-Van (ex. Chevrolet Astro / GMC Safari)&#013;&#010;9 = S/T -Truck (ex. Chevrolet S10 Truck / Blazer)&#013;&#010;10 = P-Body</description>
+    <CATEGORYMEM index="0" category="17" />
+    <EMBEDDEDDATA mmedaddress="0x1F77D" mmedelementsizebits="8" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <decimalpl>0</decimalpl>
+    <rangehigh>10.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x464E" flags="0x30">
+    <title>G1207 - Vehicle Platform Options</title>
+    <description>This table shows what options are available for each Vehicle Platform.  Whichever Platform is defined in Vehicle Platform (G1206) will determine which column to should use to add or remove an option.&#013;&#010;&#013;&#010;0 = Option is NOT present&#013;&#010;1 = Option IS present&#013;&#010;&#013;&#010;Legend:&#013;&#010;ETC = Electronic Throttle Control (Drive-By-Wire option)&#013;&#010;AIR = AIR Pump&#013;&#010;PS = Power Steering Pressure Switch&#013;&#010;Hot Tran = Hot Transmission Switch&#013;&#010;Alt. L = Alternator &quot;L&quot; Terminal&#013;&#010;Alt. F = Alternator &quot;F&quot; Terminal&#013;&#010;Cruise = Cruise Control Status Switch&#013;&#010;Oil Pres = Oil Pressure Sensor&#013;&#010;BTM = Brake Torque Management&#013;&#010;PTO = Power Take Off&#013;&#010;4x CKP = Low Resolution (4x) Crankshaft Position Sensor (CKP)</description>
+    <CATEGORYMEM index="0" category="17" />
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Vehicle Model</units>
+      <indexcount>11</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="F-Body" />
+      <LABEL index="1" value="Y-Body" />
+      <LABEL index="2" value="Holden" />
+      <LABEL index="3" value="GMT530" />
+      <LABEL index="4" value="GMT540" />
+      <LABEL index="5" value="GMT560" />
+      <LABEL index="6" value="GMT610" />
+      <LABEL index="7" value="GMT800" />
+      <LABEL index="8" value="ML-Van" />
+      <LABEL index="9" value="S/T-Truck" />
+      <LABEL index="10" value="P-Body" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Vehicle Platform Option</units>
+      <indexcount>11</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="ETC" />
+      <LABEL index="1" value="AIR" />
+      <LABEL index="2" value="PS" />
+      <LABEL index="3" value="Hot Tran" />
+      <LABEL index="4" value="Alt. L" />
+      <LABEL index="5" value="Alt. F" />
+      <LABEL index="6" value="Cruise" />
+      <LABEL index="7" value="Oil Pres" />
+      <LABEL index="8" value="BTM" />
+      <LABEL index="9" value="PTO" />
+      <LABEL index="10" value="4x CKP" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedtypeflags="0x04" mmedaddress="0x1F6DC" mmedelementsizebits="8" mmedrowcount="11" mmedcolcount="11" mmedmajorstridebits="0" mmedminorstridebits="16" />
+      <units>Option Present</units>
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>1.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCONSTANT uniqueid="0x3BCF" flags="0xC">
+    <title>H0101 - Vehicle Speed Sensor (VSS) Pulses per Mile</title>
+    <description>The number of Pulses the Speed Sensor produces per Mile.  This value is used to determine the vehicle&apos;s actual Speed, and controls the Speedometer Needle in the Instrument Cluster.&#013;&#010;&#013;&#010;Increasing this value (H0101) will reduce the indicated speed of the Speedometer.&#013;&#010;Decreasing this value (H0101) will increase the indicated speed of the Speedometer.&#013;&#010;&#013;&#010;This value MUST be manually calculated by YOU.  Some tuning software have an automated calculator &quot;Wizard&quot;.&#013;&#010;&#013;&#010;H0101 is calculated using this formula:  H0101 = (H0102 x H0103 x 63360) &#247; (Tire Diameter x Pi)&#013;&#010;&#013;&#010;Where:&#013;&#010;H0101 = Vehicle Speed Sensor Pulses per Mile&#013;&#010;H0102 = Vehicle Speed Sensor (VSS) Pulses per Revolution (typically 17 or 40)&#013;&#010;H0103 = Axle or Differential Gear Ratio  (eg. 3.73)&#013;&#010;Tire Diameter = tire diameter in inches&#013;&#010;Pi = 3.14159</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FECC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Pulses / Mile</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>253436.000000</rangehigh>
+    <rangelow>100.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*(1000/256)">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0xDC5" flags="0xC">
+    <title>H0102 - Vehicle Speed Sensor (VSS) Pulses per Revolution</title>
+    <description>The number of Pulses the Speed Sensor produces per single Transmission Output Shaft (TOS) revolution.  This is typically the same as the number of teeth on the Vehicle Speed Sensor (VSS) reluctor ring.&#013;&#010;&#013;&#010;For Manual Transmission vehicles this value is typically set to 17 (most cars) or 40 (some trucks).</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x19632" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Pulses / Rev</units>
+    <rangehigh>50.000000</rangehigh>
+    <rangelow>10.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/256">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x3C82" flags="0xC">
+    <title>H0103 - Axle (Differential) Gear Ratio</title>
+    <description>This value is used by the Torque subsystem to estimate the Axle Torque.  It is NOT used by the PCM for calculating either the Speedometer or the Transmission Shift Speeds.</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FEDC" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Ratio</units>
+    <decimalpl>3</decimalpl>
+    <rangehigh>6.000000</rangehigh>
+    <rangelow>1.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.00024414">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x30B5" flags="0xC">
+    <title>H0104 - Transmission Output Shaft (TOS) Revolutions per Mile</title>
+    <description>The number of Revolutions per Mile of the Transmission Output Shaft (TOS).  This is used by the PCM to determine the Transmission Shift Speeds.&#013;&#010;&#013;&#010;This value MUST be manually calculated by YOU.  Some tuning software have an automated calculator &quot;Wizard&quot;.&#013;&#010;&#013;&#010;H0104 is calculated using this formula:  H0104 = H0101 &#247; H0102&#013;&#010;&#013;&#010;*** You must first calculate H0101 ***&#013;&#010;&#013;&#010;Where:&#013;&#010;H0101 = Vehicle Speed Sensor Pulses per Mile&#013;&#010;H0102 = Vehicle Speed Sensor (VSS) Pulses per Revolution (typically 17 or 40)&#013;&#010;H0104 = Transmission Output Shaft (TOS) Revolutions per Mile</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1D450" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Revs / Mile</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>5000.000000</rangehigh>
+    <rangelow>16.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.05859372">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x7982" flags="0xC">
+    <title>H0105 - PCM Primary (4K) Pulses per Mile Output Rate</title>
+    <description>The number of Pulses the PCM Primary Speed Output (C2 (Red) pin 50) produces per Mile.&#013;&#010;&#013;&#010;This is the PCM output to the Speedometer.</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FED0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Pulses / Mile</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>255996.000000</rangehigh>
+    <rangelow>1000.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*3.90625">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x5140" flags="0xC">
+    <title>H0106 - PCM Secondary (128K) Pulses per Mile Output Rate</title>
+    <description>The number of Pulses the PCM Secondary Speed Output (C2 (Red) pin 49) produces per Mile.&#013;&#010;&#013;&#010;This is the PCM output to the ABS Module.</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FED2" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Pulses / Mile</units>
+    <decimalpl>0</decimalpl>
+    <rangehigh>255996.000000</rangehigh>
+    <rangelow>1000.000000</rangelow>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*3.90625">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6CA6" flags="0xC">
+    <title>H0107 - Vehicle Stationary Timer</title>
+    <description>If the PCM has not received any Vehicle Speed Sensor (VSS) pulses for this long (seconds), then the vehicle is considered to be stationary.</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FED4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>Seconds</units>
+    <rangehigh>409.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X/160">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x50C0" flags="0xC">
+    <title>H0108 - Electronic Throttle Control (ETC) Speed Governor</title>
+    <description>Used only on Electronic Throttle Control (ETC) vehicles.  This is the Speed to which the ETC will attempt to govern the vehicle.&#013;&#010;This maybe used to prevent oil starvation under high lateral g-forces, or as the vehicle overspeed limiter instead of using the fuel cut Speed limiters.</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FED6" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0078125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x1068" flags="0xC">
+    <title>H0109 - Maximum Vehicle Speed (Non-ETC)</title>
+    <description>Maximum allowed Vehicle Speed before Fuel is shutoff on vehicles without Electronic Throttle Control (ETC).</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FEE4" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0078125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x6C9C" flags="0xC">
+    <title>H0111 - Maximum Vehicle Speed (with ETC)</title>
+    <description>Maximum allowed Vehicle Speed before Fuel is shutoff on vehicles with Electronic Throttle Control (ETC).</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FEE8" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0078125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x637B" flags="0xC">
+    <title>H0113 - Speed Limiter Hysteresis</title>
+    <description>If the Fuel has been shutoff due to the Maximum Allowed Speed being reached, the Speed must fall by this much before Fuel will be re-Enabled.</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FEEA" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0078125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFCONSTANT uniqueid="0x52C5" flags="0xC">
+    <title>H0114 - Maximum Vehicle Speed with RTD Fault</title>
+    <description>If the PCM has detected a Fault with the Real Time Damping (RTD) System (i.e. Active Suspension System), this will be the Maximum Vehicle Speed allowed.</description>
+    <CATEGORYMEM index="0" category="19" />
+    <EMBEDDEDDATA mmedaddress="0x1FEE0" mmedelementsizebits="16" mmedmajorstridebits="0" mmedminorstridebits="0" />
+    <units>MPH</units>
+    <decimalpl>1</decimalpl>
+    <rangehigh>254.000000</rangehigh>
+    <datatype>0</datatype>
+    <unittype>0</unittype>
+    <DALINK index="0" />
+    <MATH equation="X*0.0078125">
+      <VAR id="X" />
+    </MATH>
+  </XDFCONSTANT>
+  <XDFTABLE uniqueid="0x5E6" flags="0x30">
+    <title>Operating System</title>
+    <description>This is the main Operating System (OS) programmed in the calibration.&#013;&#010;&#013;&#010;*** This parameter should NOT be changed ***&#013;&#010;&#013;&#010;This is displayed solely to ensure that the correct XDF file is used to edit the BIN file.</description>
+    <XDFAXIS id="x" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Calibration #</units>
+      <indexcount>1</indexcount>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="0.00" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="y" uniqueid="0x0">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedmajorstridebits="-32" mmedminorstridebits="0" />
+      <units>Segment</units>
+      <indexcount>1</indexcount>
+      <outputtype>4</outputtype>
+      <datatype>0</datatype>
+      <unittype>0</unittype>
+      <DALINK index="0" />
+      <LABEL index="0" value="Oper System" />
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+    </XDFAXIS>
+    <XDFAXIS id="z">
+      <EMBEDDEDDATA mmedelementsizebits="16" mmedrowcount="1" mmedmajorstridebits="0" mmedminorstridebits="0" />
+      <decimalpl>0</decimalpl>
+      <min>0.000000</min>
+      <max>0.000000</max>
+      <outputtype>1</outputtype>
+      <MATH equation="X">
+        <VAR id="X" />
+      </MATH>
+      <MATH row="1" col="1" equation="X">
+        <VAR id="X" type="address" address="0x504" sizeinbits="32" />
+      </MATH>
+    </XDFAXIS>
+  </XDFTABLE>
+  <XDFCHECKSUM uniqueid="0x74AB">
+    <title>1 - Operating System Checksum</title>
+    <REGION>
+      <pluginmoduleid>9a53f578-d1c9-40c6-8691-7a54fa789d3b</pluginmoduleid>
+      <datastart>0x0</datastart>
+      <dataend>0xFFFFD</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x500</storeaddress>
+      <calculationmethod>0x0</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+  <XDFCHECKSUM uniqueid="0x639B">
+    <title>2 - Engine Calibration Checksum</title>
+    <REGION>
+      <datastart>0x8002</datastart>
+      <dataend>0x162CF</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x8000</storeaddress>
+      <calculationmethod>0x1</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+  <XDFCHECKSUM uniqueid="0xE58">
+    <title>3 - Engine Diagnostics Checksum</title>
+    <REGION>
+      <datastart>0x162D2</datastart>
+      <dataend>0x195FF</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x162D0</storeaddress>
+      <calculationmethod>0x1</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+  <XDFCHECKSUM uniqueid="0x5D7C">
+    <title>4 - Transmission Calibration Checksum</title>
+    <REGION>
+      <datastart>0x19602</datastart>
+      <dataend>0x1D8AF</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x19600</storeaddress>
+      <calculationmethod>0x1</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+  <XDFCHECKSUM uniqueid="0x1CAF">
+    <title>5 - Transmission Diagnostics Checksum</title>
+    <REGION>
+      <datastart>0x1D8B2</datastart>
+      <dataend>0x1E1AF</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x1D8B0</storeaddress>
+      <calculationmethod>0x1</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+  <XDFCHECKSUM uniqueid="0x76F">
+    <title>6 - Fuel System Checksum</title>
+    <REGION>
+      <datastart>0x1E1B2</datastart>
+      <dataend>0x1F6BF</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x1E1B0</storeaddress>
+      <calculationmethod>0x1</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+  <XDFCHECKSUM uniqueid="0x2E9C">
+    <title>7 - System Checksum</title>
+    <REGION>
+      <datastart>0x1F6C2</datastart>
+      <dataend>0x1FEAF</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x1F6C0</storeaddress>
+      <calculationmethod>0x1</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+  <XDFCHECKSUM uniqueid="0x3C3">
+    <title>8 - Speedometer Checksum</title>
+    <REGION>
+      <datastart>0x1FEB2</datastart>
+      <dataend>0x1FFDF</dataend>
+      <datasizebits>0x10</datasizebits>
+      <storeaddress>0x1FEB0</storeaddress>
+      <calculationmethod>0x1</calculationmethod>
+    </REGION>
+  </XDFCHECKSUM>
+</XDFFORMAT>


### PR DESCRIPTION
An unlocked XDF file with added fuel gauge sender parameters for 2003 models, for proper fuel gauge operation. *All 2003 model fuel sender tables, need to be inverted from 2004 data.